### PR TITLE
Idea: Prevent `notplayer` from immediately firing upon other players after init.

### DIFF
--- a/quant.ew/files/system/notplayer_ai/notplayer_ai.lua
+++ b/quant.ew/files/system/notplayer_ai/notplayer_ai.lua
@@ -237,6 +237,11 @@ local function update()
 
     state.init_timer = state.init_timer + 1
 
+    -- The notplayer should sit around for several gameticks before moving and firing
+    if state.init_timer < 60 then
+        return
+    end
+
     local ch_x, ch_y = EntityGetTransform(state.entity)
     local potential_targets = EntityGetInRadiusWithTag(ch_x, ch_y, MAX_RADIUS, "ew_client") or {}
     local x, y = EntityGetTransform(ctx.my_player.entity)


### PR DESCRIPTION
This is somewhat of a crude attempt to solve this problem, but I thought opening a PR might be better way to kick off the discussion that just opening another issue.

The issue being addressed here is to prevent a full team death when one player dies, and before they are even aware, the newly created `notplayer` has taken their overpowered wand and killed everyone else within a few game ticks.

I've had a few runs end this way where even in the death replay after, its hard to see just how fast the death happens.


My first thought about a solution here would be to have the `update` code wait or pause on calculating (and shooting upon) other players for a set amount of time.

I noticed there was this `init_timer` added to the `notplayer`'s state, that is iterated on every update. By early returning from `update` until that timer has exceeded `60`, we are adding some amount of grace there.


The `60` was chosen fairly arbitrarily and could possibly be a configuration setting. Also, with this approach, I *think* this might make the timing of this be frame-rate dependent, which wouldn't be ideal as the frame-rate between host and client can vary a lot.


Let me know your thoughts!