### PR TITLE
Ping arrow parameters & tweaks

### DIFF
--- a/noita-proxy/assets/lang/en-US/main.ftl
+++ b/noita-proxy/assets/lang/en-US/main.ftl
@@ -152,3 +152,11 @@ Info = Info
 ## Local settings
 
 connect_settings_random_ports = Don't use a predetermined port. Makes things a bit more robust and allows multiple proxies to be launched on the same computer, but Noita will have to be launched through the proxy.
+
+##Arrow UX settings
+
+ping-note = Ping arrow parameters
+ping-lifetime = Ping arrow lifetime in seconds.
+ping-scale = Ping arrow size.
+ping-lifetime-tooltip = This parameter changes how much frames (seconds*60, since game is supposed to run 60 fps?) ping arrow lives. Range: 0-60 seconds.
+ping-scale-tooltip = This parameter changes size of ping arrow. I dont know which units it is, but range is 0-1.5 units.

--- a/noita-proxy/assets/lang/ru-RU/main.ftl
+++ b/noita-proxy/assets/lang/ru-RU/main.ftl
@@ -150,3 +150,19 @@ Info = Info
 ## Local settings
 
 connect_settings_random_ports = Don't use a predetermined port. Makes things a bit more robust and allows multiple proxies to be launched on the same computer, but Noita will have to be launched through the proxy.
+
+##Arrow UX settings
+
+ping-note = Параметры стрелочки-пинга
+ping-lifetime = Время жизни стрелки в секундах.
+ping-scale = Размер стрелки в юнитах.
+ping-lifetime-tooltip = Этот параметр изменяет время жизни стрелочки (секунды*60, т.к. игра должна работать в 60 фпс?). Диапазон: 0-60 секунд.
+ping-scale-tooltip = Этот параметр изменяет размер стрелочки. Не знаю какая единица измерения, но диапазон 0-1.5 юнита.
+
+
+
+
+
+
+
+

--- a/noita-proxy/src/net.rs
+++ b/noita-proxy/src/net.rs
@@ -26,7 +26,7 @@ use crate::player_cosmetics::{create_player_png, PlayerPngDesc};
 use crate::{
     bookkeeping::save_state::{SaveState, SaveStateEntry},
     recorder::Recorder,
-    DefaultSettings, GameSettings, PlayerColor,
+    DefaultSettings, GameSettings, PlayerColor, UXSettings,
 };
 pub mod messages;
 mod proxy_opt;
@@ -105,6 +105,7 @@ pub struct NetManagerInit {
     pub my_nickname: Option<String>,
     pub save_state: SaveState,
     pub player_color: PlayerColor,
+    pub ux_settings: UXSettings,
     pub cosmetics: (bool, bool, bool),
     pub mod_path: PathBuf,
     pub player_path: PathBuf,
@@ -599,6 +600,10 @@ impl NetManager {
             "mina_color",
             rgb[0] as u32 + ((rgb[1] as u32) << 8) + ((rgb[2] as u32) << 16),
         );
+
+        state.try_ws_write_option("ping_lifetime", self.init_settings.ux_settings.ping_lifetime);
+        state.try_ws_write_option("ping_scale", self.init_settings.ux_settings.ping_scale);
+
         let progress = settings.progress.join(",");
         state.try_ws_write_option("progress", progress.as_str());
 

--- a/quant.ew/files/system/player_ping/player_ping.lua
+++ b/quant.ew/files/system/player_ping/player_ping.lua
@@ -63,11 +63,15 @@ function module.on_world_update()
     end
 
     local i = 1
+    --ternary operators ahead
+    local lifetime = (ctx.proxy_opt.ping_lifetime ~= nil and {ctx.proxy_opt.ping_lifetime} or {900})[1]*60  
+    local custom_scale = (ctx.proxy_opt.ping_scale ~= nil and {ctx.proxy_opt.ping_scale} or {0.5})[1]
     while i <= #pings do
         local pos = pings[i]
         local frame = pos[3]
         local peer_id = pos[4]
-        if frame + 300 < GameGetFrameNum() then
+        local alpha = 1 - ((GameGetFrameNum() - frame) / lifetime)
+        if frame + lifetime < GameGetFrameNum() then
             table.remove(pings, i)
             goto continue
         end
@@ -107,12 +111,12 @@ function module.on_world_update()
 
         local img_path = "mods/quant.ew/files/system/player/tmp/".. peer_id .."_ping.png"
         if outside then
-            local scale = math.max(1 / 6, 0.75 - math.atan((math.sqrt(dist_sq) - tch) / 1280) / math.pi)
+            local scale = math.max(1 / 6, 0.75 - math.atan((math.sqrt(dist_sq) - tch) / 1280) / math.pi) + custom_scale
             local x, y = world2gui(ccx+player_dir_x, ccy+player_dir_y)
-            GuiImage(gui, gui_id, x, y, img_path, 1, scale, 0, math.atan2(player_dir_y, player_dir_x) + math.pi/2)
+            GuiImage(gui, gui_id, x, y, img_path, alpha, scale, 0, math.atan2(player_dir_y, player_dir_x) + math.pi/2)
         else
             local x, y = world2gui(pos[1], pos[2])
-            GuiImage(gui, gui_id, x, y, img_path, 1, 0.75, 0, math.pi)
+            GuiImage(gui, gui_id, x, y, img_path, alpha, 0.75 + custom_scale, 0, math.pi)
         end
         gui_id = gui_id + 1
         i = i + 1


### PR DESCRIPTION
Added two sliders in proxy menu which allow to modify ping arrow parameters such as lifetime and scale.
Scaling was added so that you could play on ultrawide monitors without having to rotate whole body to see an arrow.
Lifetime was added because we, as a party, constantly were losing chests & another items when pings were disappearing too fast.
Also made arrows be proportionally transparent with time, so they wont clutter UI as much.
<details><summary>Ingame GIF</summary>

![noita](https://github.com/user-attachments/assets/a25714a4-9cb5-4afa-a76a-eb99514da79c)

</details> 
<details><summary>Added UI elements</summary>

![image](https://github.com/user-attachments/assets/d8c71820-8ebb-443f-b75e-76908e53074d)

</details> 
