### PR TITLE
add cmd arg for noita exe path

### DIFF
--- a/noita-proxy/src/bookkeeping/mod_manager.rs
+++ b/noita-proxy/src/bookkeeping/mod_manager.rs
@@ -21,6 +21,8 @@ use crate::{
     steam_helper::SteamState,
 };
 
+use crate::util::args::Args;
+
 #[derive(Default)]
 enum State {
     #[default]
@@ -150,9 +152,16 @@ impl Modmanager {
         ui: &mut Ui,
         settings: &mut ModmanagerSettings,
         steam_state: Option<&mut SteamState>,
+        args: &Args,
     ) {
         if let State::JustStarted = self.state {
-            if check_path_valid(&settings.game_exe_path) {
+            if let Some(path) = &args.exe_path {
+                if check_path_valid(path) {
+                    settings.game_exe_path = path.to_path_buf();
+                    info!("Path from command line is valid, checking mod now");
+                    self.state = State::PreCheckMod;
+                }
+            } else if check_path_valid(&settings.game_exe_path) {
                 info!("Path is valid, checking mod now");
                 self.state = State::PreCheckMod;
             } else {

--- a/noita-proxy/src/lib.rs
+++ b/noita-proxy/src/lib.rs
@@ -1501,6 +1501,7 @@ impl eframe::App for App {
                             ui,
                             &mut self.modmanager_settings,
                             self.steam_state.as_mut().ok(),
+                            &self.args,
                         )
                     });
                 if self.modmanager.is_done() {

--- a/noita-proxy/src/util/args.rs
+++ b/noita-proxy/src/util/args.rs
@@ -20,4 +20,7 @@ pub struct Args {
     /// host either steam or ip.
     #[argh(option)]
     pub host: Option<String>,
+    /// noita.exe path
+    #[argh(option)]
+    pub exe_path: Option<PathBuf>,
 }


### PR DESCRIPTION
Makes noita proxy skip every other path check, if VALID path was provided via command line arguments. Useful in scenarios when you use alias/.desktop to launch proxy, when it sometimes will "forget" about what folder noita.exe has been in.