### PR TITLE
Changed file dialog to native via rfd

### DIFF
--- a/noita-proxy/Cargo.toml
+++ b/noita-proxy/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 
 [dependencies]
 eframe = { version="0.29.1", features = ["glow", "default_fonts"], default-features = false }
-egui-file-dialog = "0.7.0"
+rfd = "0.15.1"
 egui_extras = { version = "0.29.1", features = ["all_loaders"] }
 egui_plot = "0.29.0"
 image = { version = "0.25.1", default-features = false, features = ["png", "webp"] }


### PR DESCRIPTION
egui_file_dialog was pretty unstable on my system, so i thought it would be good idea to use native file dialogs instead. They provide bookmarks, latest accessed locations, which is better for user anyway.
Also egui_file_dialog was ignoring doubleclicks sometimes, and is not updated regularly.

Yes, bgkillas, it is not sleek looking on windows compared to eguis' UI, i agree, but at least it would always work on any system.

Tested on Manjaro Gnome Wayland built with Ubuntu 20.04 docker container, Windows 10 in VM built via github-actions artifact.