### PR TITLE
Add apt caching to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: i686-pc-windows-gnu
-      - name: Install extra deps
-        run: sudo apt-get install -y gcc-mingw-w64-i686
+      - uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: gcc-mingw-w64-i686
+          version: 1.0
       
       - uses: Swatinem/rust-cache@v2
         with:
@@ -40,8 +42,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: x86_64-pc-windows-gnu
-      - name: Install extra deps
-        run: sudo apt-get install -y libclang-dev libgtk-3-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev libssl-dev gcc-mingw-w64-i686 gcc-mingw-w64
+      - uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: libclang-dev libgtk-3-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev libssl-dev gcc-mingw-w64-i686 gcc-mingw-w64
+          version: 1.0
       
       - uses: Swatinem/rust-cache@v2
         with:
@@ -67,9 +71,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: x86_64-pc-windows-gnu
-      - name: Install extra deps
-        run: sudo apt-get install -y libclang-dev libgtk-3-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev libssl-dev gcc-mingw-w64-i686 gcc-mingw-w64
-      
+      - uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: libclang-dev libgtk-3-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev libssl-dev gcc-mingw-w64-i686 gcc-mingw-w64
+          version: 1.0
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: noita-proxy -> target


### PR DESCRIPTION
Speed up compiling of artifacts on github, they are not updated regularly anyway. Also helps with APT ignoring packages multiple times on install because of API limitations or something, since we dont need to download them. 