### PR TITLE
nix+flake: init with noita-proxy package, overlay, and devshell 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ save_state
 /quant.ew/ewext1.dll
 /blob_guy/blob_guy/blob_guy.dll
 /blob_guy/target
+
+# Nix
+/result
+/result-man

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,65 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1759070547,
+        "narHash": "sha256-JVZl8NaVRYb0+381nl7LvPE+A774/dRpif01FKLrYFQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "647e5c14cbd5067f44ac86b74f014962df460840",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay",
+        "systems": "systems"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1759199574,
+        "narHash": "sha256-w24RYly3VSVKp98rVfCI1nFYfQ0VoWmShtKPCbXgK6A=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "381776b12d0d125edd7c1930c2041a1471e586c0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,11 @@
     in {
       overlays = import ./nix/overlays { inherit self lib rust-overlay; };
 
+      packages = lib.mapAttrs (system: pkgs: {
+        default = self.packages.${system}.noita-proxy;
+        inherit (pkgs) noita-proxy;
+      }) pkgsFor;
+
       devShells = lib.mapAttrs
         (system: pkgs: { default = pkgs.callPackage ./nix/shell.nix { }; })
         pkgsFor;

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,34 @@
+{
+  description = "Noita Entangled Worlds";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    systems = {
+      url = "github:nix-systems/default";
+      flake = false;
+    };
+  };
+  outputs = { self, nixpkgs, rust-overlay, systems, }:
+    let
+      inherit (nixpkgs) lib;
+      eachSystem = lib.genAttrs (import systems);
+      pkgsFor = eachSystem (system:
+        import nixpkgs {
+          localSystem = system;
+          overlays = [ self.overlays.default ];
+        });
+    in {
+      overlays = import ./nix/overlays { inherit self lib rust-overlay; };
+
+      devShells = lib.mapAttrs
+        (system: pkgs: { default = pkgs.callPackage ./nix/shell.nix { }; })
+        pkgsFor;
+
+      formatter =
+        eachSystem (system: nixpkgs.legacyPackages.${system}.nixfmt-classic);
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -27,6 +27,8 @@
       packages = lib.mapAttrs (system: pkgs: {
         default = self.packages.${system}.noita-proxy;
         inherit (pkgs) noita-proxy;
+        noita-proxy-stable =
+          (pkgs.extend self.overlays.noita-proxy-stable).noita-proxy;
       }) pkgsFor;
 
       devShells = lib.mapAttrs

--- a/nix/overlays/default.nix
+++ b/nix/overlays/default.nix
@@ -1,0 +1,14 @@
+{ self, lib, rust-overlay }: {
+  default = lib.composeManyExtensions [
+    # This is to ensure that other overlays and invocations of `callPackage`
+    # receive `rust-bin`, but without hard-coding a specific derivation.
+    # This can be overridden by consumers.
+    self.overlays.rust-overlay
+  ];
+
+  # This flake exposes `overlays.rust-overlay` which is automatically applied
+  # by `overlays.default`. This overlay is intended to provide `rust-bin` for
+  # the package overlay, in the event it is not already present.
+  rust-overlay = final: prev:
+    if prev ? rust-bin then { } else rust-overlay.overlays.default final prev;
+}

--- a/nix/overlays/default.nix
+++ b/nix/overlays/default.nix
@@ -1,9 +1,14 @@
-{ self, lib, rust-overlay }: {
+{ self, lib, rust-overlay }:
+let rustPackageOverlay = import ./rust-package.nix;
+in {
   default = lib.composeManyExtensions [
     # This is to ensure that other overlays and invocations of `callPackage`
     # receive `rust-bin`, but without hard-coding a specific derivation.
     # This can be overridden by consumers.
     self.overlays.rust-overlay
+
+    # Packages provided by this flake:
+    self.overlays.noita-proxy
   ];
 
   # This flake exposes `overlays.rust-overlay` which is automatically applied
@@ -11,4 +16,12 @@
   # the package overlay, in the event it is not already present.
   rust-overlay = final: prev:
     if prev ? rust-bin then { } else rust-overlay.overlays.default final prev;
+
+  # The overlay definition uses `rust-bin` to construct a `rustPlatform`,
+  # and `rust-bin` is not provided by this particular overlay.
+  # Prefer using `overlays.default`, or composing with `rust-overlay` manually.
+  noita-proxy = rustPackageOverlay {
+    packageName = "noita-proxy";
+    sourceRoot = self;
+  };
 }

--- a/nix/overlays/default.nix
+++ b/nix/overlays/default.nix
@@ -20,8 +20,14 @@ in {
   # The overlay definition uses `rust-bin` to construct a `rustPlatform`,
   # and `rust-bin` is not provided by this particular overlay.
   # Prefer using `overlays.default`, or composing with `rust-overlay` manually.
+
   noita-proxy = rustPackageOverlay {
     packageName = "noita-proxy";
     sourceRoot = self;
+  };
+
+  noita-proxy-stable = rustPackageOverlay {
+    packageName = "noita-proxy-stable";
+    packageAttr = "noita-proxy";
   };
 }

--- a/nix/overlays/rust-package.nix
+++ b/nix/overlays/rust-package.nix
@@ -1,0 +1,20 @@
+# This function is imported as `rustPackageOverlay` in `nix/overlays/default.nix`.
+#
+# Supplies a stable `rustPlatform` from `rust-bin` to `callPackage`.
+# The `rust-overlay` must have already been composed onto the `pkgs` set.
+#
+# This prevents `rust-bin` from being an input of the package, which would
+# make it less portable.
+{ packageName, sourceRoot }:
+final: _prev:
+let
+  rust-stable = final.rust-bin.stable.latest.minimal;
+  rustPlatform = final.makeRustPlatform {
+    cargo = rust-stable;
+    rustc = rust-stable;
+  };
+in {
+  ${packageName} = final.callPackage "${../packages}/${packageName}.nix" {
+    inherit sourceRoot rustPlatform;
+  };
+}

--- a/nix/overlays/rust-package.nix
+++ b/nix/overlays/rust-package.nix
@@ -5,7 +5,7 @@
 #
 # This prevents `rust-bin` from being an input of the package, which would
 # make it less portable.
-{ packageName, sourceRoot }:
+args@{ packageName, packageAttr ? packageName, ... }:
 final: _prev:
 let
   rust-stable = final.rust-bin.stable.latest.minimal;
@@ -14,7 +14,8 @@ let
     rustc = rust-stable;
   };
 in {
-  ${packageName} = final.callPackage "${../packages}/${packageName}.nix" {
-    inherit sourceRoot rustPlatform;
-  };
+  ${packageAttr} = final.callPackage "${../packages}/${packageName}.nix"
+    ((removeAttrs args [ "packageName" "packageAttr" ]) // {
+      inherit rustPlatform;
+    });
 }

--- a/nix/packages/noita-proxy-stable.nix
+++ b/nix/packages/noita-proxy-stable.nix
@@ -1,0 +1,11 @@
+# TODO: Update script & CI
+{ callPackage, fetchFromGitHub, rustPlatform }:
+(callPackage ./noita-proxy.nix {
+  sourceRoot = fetchFromGitHub {
+    owner = "intquant";
+    repo = "noita_entangled_worlds";
+    rev = "v1.6.2";
+    hash = "sha256-DAGLpGo8K6qSfxMwTELSU9HLHRX2lp5qbmmq/tL08JM=";
+  };
+  inherit rustPlatform;
+})

--- a/nix/packages/noita-proxy.nix
+++ b/nix/packages/noita-proxy.nix
@@ -1,0 +1,68 @@
+{ sourceRoot, lib, runCommandNoCC, rustPlatform, pkg-config, cmake, patchelf
+, openssl, libjack2, alsa-lib, libopus, wayland, libxkbcommon, libGL }:
+
+rustPlatform.buildRustPackage (finalAttrs:
+  let
+    inherit (finalAttrs) src pname version buildInputs steamworksRedist;
+    manifest = lib.importTOML "${src}/noita-proxy/Cargo.toml";
+  in {
+    pname = "noita-entangled-worlds-proxy";
+    inherit (manifest.package) version;
+
+    # The real root of the entire project.
+    # This is the only place `sourceRoot` is used.
+    src = sourceRoot;
+    # The root of this particular binary crate to build.
+    sourceRoot = "source/noita-proxy";
+
+    cargoLock.lockFile = "${src}/noita-proxy/Cargo.lock";
+
+    strictDeps = true;
+    nativeBuildInputs = [ pkg-config cmake patchelf ];
+
+    # TODO: Add dependencies for X11 desktop environments.
+    buildInputs = [
+      openssl
+      libjack2
+      alsa-lib
+      libopus
+      wayland
+      libxkbcommon
+      libGL
+      steamworksRedist
+    ];
+
+    env = {
+      OPENSSL_DIR = "${lib.getDev openssl}";
+      OPENSSL_LIB_DIR = "${lib.getLib openssl}/lib";
+      OPENSSL_NO_VENDOR = 1;
+    };
+
+    checkFlags = [
+      # Disable networked tests
+      "--skip bookkeeping::releases::test::release_assets"
+    ];
+
+    postFixup = ''
+      patchelf $out/bin/noita-proxy \
+        --set-rpath ${lib.makeLibraryPath buildInputs}
+    '';
+
+    # This attribute is defined here instead of a `let` block, because in this position,
+    # it can be overridden with `overrideAttrs`, and shares a `src` with the top-level.
+    steamworksRedist =
+      runCommandNoCC "${pname}-steamworks-redist" { inherit src; } ''
+        install -Dm555 $src/redist/libsteam_api.so -t $out/lib
+      '';
+
+    meta = {
+      description = "Noita Entangled Worlds proxy application.";
+      homepage = "https://github.com/IntQuant/noita_entangled_worlds";
+      changelog =
+        "https://github.com/IntQuant/noita_entangled_worlds/releases/tag/v${version}";
+      license = with lib.licenses; [ mit asl20 ];
+      platforms = [ "x86_64-linux" ];
+      maintainers = with lib.maintainers; [ spikespaz ];
+      mainProgram = "noita-proxy";
+    };
+  })

--- a/nix/packages/noita-proxy.nix
+++ b/nix/packages/noita-proxy.nix
@@ -83,7 +83,7 @@ rustPlatform.buildRustPackage (finalAttrs:
     ];
 
     meta = {
-      description = "Noita Entangled Worlds proxy application.";
+      inherit (manifest.package) description;
       homepage = "https://github.com/IntQuant/noita_entangled_worlds";
       changelog =
         "https://github.com/IntQuant/noita_entangled_worlds/releases/tag/v${version}";

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,6 +1,8 @@
-{ rust-bin, mkShell }:
+{ rust-bin, mkShell, noita-proxy }:
 mkShell {
   strictDeps = true;
+
+  inputsFrom = [ noita-proxy ];
 
   packages = [
     # Derivations in `rust-stable` provide the toolchain,
@@ -15,4 +17,10 @@ mkShell {
         extensions = [ "rustfmt" "rust-analyzer" ];
       }))
   ];
+
+  env = {
+    inherit (noita-proxy) OPENSSL_DIR OPENSSL_LIB_DIR OPENSSL_NO_VENDOR;
+
+    RUST_BACKTRACE = 1;
+  };
 }

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,0 +1,18 @@
+{ rust-bin, mkShell }:
+mkShell {
+  strictDeps = true;
+
+  packages = [
+    # Derivations in `rust-stable` provide the toolchain,
+    # must be listed first to take precedence over nightly.
+    (rust-bin.stable.latest.minimal.override {
+      extensions = [ "rust-src" "rust-docs" "clippy" ];
+    })
+
+    # Use rustfmt, and other tools that require nightly features.
+    (rust-bin.selectLatestNightlyWith (toolchain:
+      toolchain.minimal.override {
+        extensions = [ "rustfmt" "rust-analyzer" ];
+      }))
+  ];
+}

--- a/noita-proxy/Cargo.toml
+++ b/noita-proxy/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "noita-proxy"
-description = "Noita Entangled Worlds companion app."
+description = "Noita Entangled Worlds proxy application."
 version = "1.6.2"
 edition = "2024"
 


### PR DESCRIPTION
This makes it easy for Nix/OS users to `nix develop` and have a working environment with all dependencies required for contributing.

Also provides a package for downstream consumers using the Nix package manager for general software acquisition.

There is an adjacent change in `noita-proxy/Cargo.toml`, I have modified the description slightly to say "proxy application" instead of "companion app" because I believe the former is more accurate.

I would appreciate if you did not squash my commits. I take great care to ensure that they are easy to review individually, as I build up the stated feature. Please rebase-merge my pull requests.