### PR TITLE
Refactor nix with `nixfmt`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -13,16 +13,25 @@
     };
   };
 
-  outputs = { self, nixpkgs, rust-overlay, systems, }:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      rust-overlay,
+      systems,
+    }:
     let
       inherit (nixpkgs) lib;
       eachSystem = lib.genAttrs (import systems);
-      pkgsFor = eachSystem (system:
+      pkgsFor = eachSystem (
+        system:
         import nixpkgs {
           localSystem = system;
           overlays = [ self.overlays.default ];
-        });
-    in {
+        }
+      );
+    in
+    {
       overlays = import ./nix/overlays { inherit self lib rust-overlay; };
 
       packages = lib.mapAttrs (system: pkgs: {
@@ -30,11 +39,10 @@
         inherit (pkgs) noita-proxy;
       }) pkgsFor;
 
-      devShells = lib.mapAttrs
-        (system: pkgs: { default = pkgs.callPackage ./nix/shell.nix { }; })
-        pkgsFor;
+      devShells = lib.mapAttrs (system: pkgs: {
+        default = pkgs.callPackage ./nix/shell.nix { };
+      }) pkgsFor;
 
-      formatter =
-        eachSystem (system: nixpkgs.legacyPackages.${system}.nixfmt-classic);
+      formatter = eachSystem (system: nixpkgs.legacyPackages.${system}.nixfmt-classic);
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -43,6 +43,6 @@
         default = pkgs.callPackage ./nix/shell.nix { };
       }) pkgsFor;
 
-      formatter = eachSystem (system: nixpkgs.legacyPackages.${system}.nixfmt-classic);
+      formatter = eachSystem (system: nixpkgs.legacyPackages.${system}.nixfmt-tree);
     };
 }

--- a/nix/overlays/default.nix
+++ b/nix/overlays/default.nix
@@ -1,6 +1,12 @@
-{ self, lib, rust-overlay }:
-let rustPackageOverlay = import ./rust-package.nix;
-in {
+{
+  self,
+  lib,
+  rust-overlay,
+}:
+let
+  rustPackageOverlay = import ./rust-package.nix;
+in
+{
   default = lib.composeManyExtensions [
     # This is to ensure that other overlays and invocations of `callPackage`
     # receive `rust-bin`, but without hard-coding a specific derivation.
@@ -14,8 +20,8 @@ in {
   # This flake exposes `overlays.rust-overlay` which is automatically applied
   # by `overlays.default`. This overlay is intended to provide `rust-bin` for
   # the package overlay, in the event it is not already present.
-  rust-overlay = final: prev:
-    if prev ? rust-bin then { } else rust-overlay.overlays.default final prev;
+  rust-overlay =
+    final: prev: if prev ? rust-bin then { } else rust-overlay.overlays.default final prev;
 
   # The overlay definition uses `rust-bin` to construct a `rustPlatform`,
   # and `rust-bin` is not provided by this particular overlay.

--- a/nix/overlays/rust-package.nix
+++ b/nix/overlays/rust-package.nix
@@ -13,7 +13,8 @@ let
     cargo = rust-stable;
     rustc = rust-stable;
   };
-in {
+in
+{
   ${packageName} = final.callPackage "${../packages}/${packageName}.nix" {
     inherit sourceRoot rustPlatform;
   };

--- a/nix/packages/noita-proxy.nix
+++ b/nix/packages/noita-proxy.nix
@@ -1,12 +1,37 @@
-{ sourceRoot, lib, runCommandNoCC, rustPlatform, copyDesktopItems
-, makeDesktopItem, pkg-config, cmake, patchelf, imagemagick, openssl, libjack2
-, alsa-lib, libopus, wayland, libxkbcommon, libGL }:
+{
+  sourceRoot,
+  lib,
+  runCommandNoCC,
+  rustPlatform,
+  copyDesktopItems,
+  makeDesktopItem,
+  pkg-config,
+  cmake,
+  patchelf,
+  imagemagick,
+  openssl,
+  libjack2,
+  alsa-lib,
+  libopus,
+  wayland,
+  libxkbcommon,
+  libGL,
+}:
 
-rustPlatform.buildRustPackage (finalAttrs:
+rustPlatform.buildRustPackage (
+  finalAttrs:
   let
-    inherit (finalAttrs) src pname version meta buildInputs steamworksRedist;
+    inherit (finalAttrs)
+      src
+      pname
+      version
+      meta
+      buildInputs
+      steamworksRedist
+      ;
     manifest = lib.importTOML "${src}/noita-proxy/Cargo.toml";
-  in {
+  in
+  {
     pname = "noita-entangled-worlds-proxy";
     inherit (manifest.package) version;
 
@@ -19,8 +44,13 @@ rustPlatform.buildRustPackage (finalAttrs:
     cargoLock.lockFile = "${src}/noita-proxy/Cargo.lock";
 
     strictDeps = true;
-    nativeBuildInputs =
-      [ copyDesktopItems pkg-config cmake patchelf imagemagick ];
+    nativeBuildInputs = [
+      copyDesktopItems
+      pkg-config
+      cmake
+      patchelf
+      imagemagick
+    ];
 
     # TODO: Add dependencies for X11 desktop environments.
     buildInputs = [
@@ -63,10 +93,9 @@ rustPlatform.buildRustPackage (finalAttrs:
 
     # This attribute is defined here instead of a `let` block, because in this position,
     # it can be overridden with `overrideAttrs`, and shares a `src` with the top-level.
-    steamworksRedist =
-      runCommandNoCC "${pname}-steamworks-redist" { inherit src; } ''
-        install -Dm555 $src/redist/libsteam_api.so -t $out/lib
-      '';
+    steamworksRedist = runCommandNoCC "${pname}-steamworks-redist" { inherit src; } ''
+      install -Dm555 $src/redist/libsteam_api.so -t $out/lib
+    '';
 
     desktopItems = [
       (makeDesktopItem {
@@ -75,8 +104,17 @@ rustPlatform.buildRustPackage (finalAttrs:
         comment = meta.description;
         exec = "noita-proxy";
         icon = "noita-proxy";
-        categories = [ "Game" "Utility" ];
-        keywords = [ "noita" "proxy" "server" "steam" "game" ];
+        categories = [
+          "Game"
+          "Utility"
+        ];
+        keywords = [
+          "noita"
+          "proxy"
+          "server"
+          "steam"
+          "game"
+        ];
         terminal = false;
         singleMainWindow = true;
       })
@@ -85,11 +123,14 @@ rustPlatform.buildRustPackage (finalAttrs:
     meta = {
       inherit (manifest.package) description;
       homepage = "https://github.com/IntQuant/noita_entangled_worlds";
-      changelog =
-        "https://github.com/IntQuant/noita_entangled_worlds/releases/tag/v${version}";
-      license = with lib.licenses; [ mit asl20 ];
+      changelog = "https://github.com/IntQuant/noita_entangled_worlds/releases/tag/v${version}";
+      license = with lib.licenses; [
+        mit
+        asl20
+      ];
       platforms = [ "x86_64-linux" ];
       maintainers = with lib.maintainers; [ spikespaz ];
       mainProgram = "noita-proxy";
     };
-  })
+  }
+)

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,4 +1,8 @@
-{ rust-bin, mkShell, noita-proxy }:
+{
+  rust-bin,
+  mkShell,
+  noita-proxy,
+}:
 mkShell {
   strictDeps = true;
 
@@ -8,14 +12,23 @@ mkShell {
     # Derivations in `rust-stable` provide the toolchain,
     # must be listed first to take precedence over nightly.
     (rust-bin.stable.latest.minimal.override {
-      extensions = [ "rust-src" "rust-docs" "clippy" ];
+      extensions = [
+        "rust-src"
+        "rust-docs"
+        "clippy"
+      ];
     })
 
     # Use rustfmt, and other tools that require nightly features.
-    (rust-bin.selectLatestNightlyWith (toolchain:
+    (rust-bin.selectLatestNightlyWith (
+      toolchain:
       toolchain.minimal.override {
-        extensions = [ "rustfmt" "rust-analyzer" ];
-      }))
+        extensions = [
+          "rustfmt"
+          "rust-analyzer"
+        ];
+      }
+    ))
   ];
 
   env = {


### PR DESCRIPTION
With the new `nixfmt` and nix formatting RFC merged. We should use the new formatting forward for consistency.