### PR TITLE
Update Nix and cross-compilation

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -13,16 +13,25 @@
     };
   };
 
-  outputs = { self, nixpkgs, rust-overlay, systems, }:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      rust-overlay,
+      systems,
+    }:
     let
       inherit (nixpkgs) lib;
       eachSystem = lib.genAttrs (import systems);
-      pkgsFor = eachSystem (system:
+      pkgsFor = eachSystem (
+        system:
         import nixpkgs {
           localSystem = system;
           overlays = [ self.overlays.default ];
-        });
-    in {
+        }
+      );
+    in
+    {
       overlays = import ./nix/overlays { inherit self lib rust-overlay; };
 
       packages = lib.mapAttrs (system: pkgs: {
@@ -30,11 +39,10 @@
         inherit (pkgs) noita-proxy;
       }) pkgsFor;
 
-      devShells = lib.mapAttrs
-        (system: pkgs: { default = pkgs.callPackage ./nix/shell.nix { }; })
-        pkgsFor;
+      devShells = lib.mapAttrs (system: pkgs: {
+        default = pkgs.callPackage ./nix/shell.nix { };
+      }) pkgsFor;
 
-      formatter =
-        eachSystem (system: nixpkgs.legacyPackages.${system}.nixfmt-classic);
+      formatter = eachSystem (system: nixpkgs.legacyPackages.${system}.nixfmt-classic);
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -41,6 +41,10 @@
 
       devShells = lib.mapAttrs (system: pkgs: {
         default = pkgs.callPackage ./nix/shell.nix { };
+
+        # devShells for cross-compiling. You may use ./nix/cross/build-* directly instead.
+        cross-ewext = pkgs.callPackage ./nix/cross/ewext.nix { };
+        cross-noita-proxy = pkgs.callPackage ./nix/cross/noita-proxy.nix { };
       }) pkgsFor;
 
       formatter = eachSystem (system: nixpkgs.legacyPackages.${system}.nixfmt-tree);

--- a/flake.nix
+++ b/flake.nix
@@ -43,6 +43,6 @@
         default = pkgs.callPackage ./nix/shell.nix { };
       }) pkgsFor;
 
-      formatter = eachSystem (system: nixpkgs.legacyPackages.${system}.nixfmt-classic);
+      formatter = eachSystem (system: nixpkgs.legacyPackages.${system}.nixfmt-tree);
     };
 }

--- a/nix/cross/README.md
+++ b/nix/cross/README.md
@@ -1,0 +1,1 @@
+This directory include Nix configurations for locally cross-compiling duing development becaues Nix derivation does not support Rust's incremental compilation.

--- a/nix/cross/build-ewext
+++ b/nix/cross/build-ewext
@@ -1,0 +1,7 @@
+#! /usr/bin/env nix
+#! nix develop ../..#cross-ewext --command bash
+
+# You can pass any arguments to this script which will be passed to cargo
+# e.g. `./build-ewext --release`
+
+cargo build --target=i686-pc-windows-gnu -Zbuild-std="panic_abort,std" "$@"

--- a/nix/cross/build-noita-proxy
+++ b/nix/cross/build-noita-proxy
@@ -1,0 +1,7 @@
+#! /usr/bin/env nix
+#! nix develop ../..#cross-noita-proxy --command bash
+
+# You can pass any arguments to this script which will be passed to cargo
+# e.g. `./build-noita-proxy --release`
+
+cargo build --target=x86_64-pc-windows-gnu "$@"

--- a/nix/cross/ewext.nix
+++ b/nix/cross/ewext.nix
@@ -1,0 +1,40 @@
+{
+  mkShell,
+  rust-bin,
+  pkgsCross,
+}:
+let
+  # DLLs required for windows.
+  dylibs = [
+    pkgsCross.mingw32.windows.pthreads
+    pkgsCross.mingw32.windows.mcfgthreads
+  ];
+in
+mkShell {
+  packages = [
+    (rust-bin.selectLatestNightlyWith (
+      toolchain:
+      toolchain.minimal.override {
+        extensions = [
+          "rustfmt"
+          "rust-analyzer"
+          "rust-src"
+          "rust-docs"
+          "clippy"
+        ];
+        targets = [ "i686-pc-windows-gnu" ];
+      }
+    ))
+    pkgsCross.mingw32.buildPackages.gcc
+  ];
+  RUSTFLAGS =
+    let
+      searchDirs = map (a: "-L ${a}/lib") dylibs;
+    in
+    [
+      "-C"
+      "link-arg=-lmcfgthread"
+    ]
+    ++ searchDirs;
+}
+

--- a/nix/cross/noita-proxy.nix
+++ b/nix/cross/noita-proxy.nix
@@ -1,0 +1,33 @@
+{
+  rust-bin,
+  mkShell,
+  noita-proxy,
+  pkgs,
+  pkgsCross,
+  lib,
+}:
+let
+  # DLLs required for windows.
+  dylibs = [
+    pkgsCross.mingwW64.windows.pthreads
+    pkgsCross.mingwW64.libopus
+  ];
+  buildInputs = [
+    noita-proxy.steamworksRedist
+  ];
+in
+mkShell {
+  packages = [
+    (rust-bin.stable.latest.minimal.override {
+      extensions = [
+        "rust-src"
+        "rust-docs"
+      ];
+      targets = [ "x86_64-pc-windows-gnu" ];
+    })
+    pkgs.pkgsCross.mingwW64.buildPackages.gcc
+  ];
+
+  LD_LIBRARY_PATH = lib.makeLibraryPath (dylibs ++ buildInputs);
+  RUSTFLAGS = map (a: "-L ${a}/lib") dylibs;
+}

--- a/nix/overlays/default.nix
+++ b/nix/overlays/default.nix
@@ -1,6 +1,12 @@
-{ self, lib, rust-overlay }:
-let rustPackageOverlay = import ./rust-package.nix;
-in {
+{
+  self,
+  lib,
+  rust-overlay,
+}:
+let
+  rustPackageOverlay = import ./rust-package.nix;
+in
+{
   default = lib.composeManyExtensions [
     # This is to ensure that other overlays and invocations of `callPackage`
     # receive `rust-bin`, but without hard-coding a specific derivation.
@@ -14,8 +20,8 @@ in {
   # This flake exposes `overlays.rust-overlay` which is automatically applied
   # by `overlays.default`. This overlay is intended to provide `rust-bin` for
   # the package overlay, in the event it is not already present.
-  rust-overlay = final: prev:
-    if prev ? rust-bin then { } else rust-overlay.overlays.default final prev;
+  rust-overlay =
+    final: prev: if prev ? rust-bin then { } else rust-overlay.overlays.default final prev;
 
   # The overlay definition uses `rust-bin` to construct a `rustPlatform`,
   # and `rust-bin` is not provided by this particular overlay.

--- a/nix/overlays/rust-package.nix
+++ b/nix/overlays/rust-package.nix
@@ -13,7 +13,8 @@ let
     cargo = rust-stable;
     rustc = rust-stable;
   };
-in {
+in
+{
   ${packageName} = final.callPackage "${../packages}/${packageName}.nix" {
     inherit sourceRoot rustPlatform;
   };

--- a/nix/packages/noita-proxy.nix
+++ b/nix/packages/noita-proxy.nix
@@ -1,12 +1,37 @@
-{ sourceRoot, lib, runCommandNoCC, rustPlatform, copyDesktopItems
-, makeDesktopItem, pkg-config, cmake, patchelf, imagemagick, openssl, libjack2
-, alsa-lib, libopus, wayland, libxkbcommon, libGL }:
+{
+  sourceRoot,
+  lib,
+  runCommandNoCC,
+  rustPlatform,
+  copyDesktopItems,
+  makeDesktopItem,
+  pkg-config,
+  cmake,
+  patchelf,
+  imagemagick,
+  openssl,
+  libjack2,
+  alsa-lib,
+  libopus,
+  wayland,
+  libxkbcommon,
+  libGL,
+}:
 
-rustPlatform.buildRustPackage (finalAttrs:
+rustPlatform.buildRustPackage (
+  finalAttrs:
   let
-    inherit (finalAttrs) src pname version meta buildInputs steamworksRedist;
+    inherit (finalAttrs)
+      src
+      pname
+      version
+      meta
+      buildInputs
+      steamworksRedist
+      ;
     manifest = lib.importTOML "${src}/noita-proxy/Cargo.toml";
-  in {
+  in
+  {
     pname = "noita-entangled-worlds-proxy";
     inherit (manifest.package) version;
 
@@ -19,8 +44,13 @@ rustPlatform.buildRustPackage (finalAttrs:
     cargoLock.lockFile = "${src}/noita-proxy/Cargo.lock";
 
     strictDeps = true;
-    nativeBuildInputs =
-      [ copyDesktopItems pkg-config cmake patchelf imagemagick ];
+    nativeBuildInputs = [
+      copyDesktopItems
+      pkg-config
+      cmake
+      patchelf
+      imagemagick
+    ];
 
     # TODO: Add dependencies for X11 desktop environments.
     buildInputs = [
@@ -63,10 +93,9 @@ rustPlatform.buildRustPackage (finalAttrs:
 
     # This attribute is defined here instead of a `let` block, because in this position,
     # it can be overridden with `overrideAttrs`, and shares a `src` with the top-level.
-    steamworksRedist =
-      runCommandNoCC "${pname}-steamworks-redist" { inherit src; } ''
-        install -Dm555 $src/redist/libsteam_api.so -t $out/lib
-      '';
+    steamworksRedist = runCommandNoCC "${pname}-steamworks-redist" { inherit src; } ''
+      install -Dm555 $src/redist/libsteam_api.so -t $out/lib
+    '';
 
     desktopItems = [
       (makeDesktopItem {
@@ -75,8 +104,17 @@ rustPlatform.buildRustPackage (finalAttrs:
         comment = meta.description;
         exec = "noita-proxy";
         icon = "noita-proxy";
-        categories = [ "Game" "Utility" ];
-        keywords = [ "noita" "proxy" "server" "steam" "game" ];
+        categories = [
+          "Game"
+          "Utility"
+        ];
+        keywords = [
+          "noita"
+          "proxy"
+          "server"
+          "steam"
+          "game"
+        ];
         terminal = false;
         singleMainWindow = true;
       })
@@ -85,11 +123,14 @@ rustPlatform.buildRustPackage (finalAttrs:
     meta = {
       inherit (manifest.package) description;
       homepage = "https://github.com/IntQuant/noita_entangled_worlds";
-      changelog =
-        "https://github.com/IntQuant/noita_entangled_worlds/releases/tag/v${version}";
-      license = with lib.licenses; [ mit asl20 ];
+      changelog = "https://github.com/IntQuant/noita_entangled_worlds/releases/tag/v${version}";
+      license = with lib.licenses; [
+        mit
+        asl20
+      ];
       platforms = [ "x86_64-linux" ];
       maintainers = with lib.maintainers; [ spikespaz ];
       mainProgram = "noita-proxy";
     };
-  })
+  }
+)

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -2,7 +2,21 @@
   rust-bin,
   mkShell,
   noita-proxy,
+  pkgs,
+  lib,
 }:
+let
+  buildInputs = with pkgs; [
+    openssl
+    libjack2
+    alsa-lib
+    libopus
+    wayland
+    libxkbcommon
+    libGL
+    noita-proxy.steamworksRedist
+  ];
+in
 mkShell {
   strictDeps = true;
 
@@ -35,5 +49,6 @@ mkShell {
     inherit (noita-proxy) OPENSSL_DIR OPENSSL_LIB_DIR OPENSSL_NO_VENDOR;
 
     RUST_BACKTRACE = 1;
+    LD_LIBRARY_PATH = lib.makeLibraryPath buildInputs;
   };
 }

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,4 +1,8 @@
-{ rust-bin, mkShell, noita-proxy }:
+{
+  rust-bin,
+  mkShell,
+  noita-proxy,
+}:
 mkShell {
   strictDeps = true;
 
@@ -8,14 +12,23 @@ mkShell {
     # Derivations in `rust-stable` provide the toolchain,
     # must be listed first to take precedence over nightly.
     (rust-bin.stable.latest.minimal.override {
-      extensions = [ "rust-src" "rust-docs" "clippy" ];
+      extensions = [
+        "rust-src"
+        "rust-docs"
+        "clippy"
+      ];
     })
 
     # Use rustfmt, and other tools that require nightly features.
-    (rust-bin.selectLatestNightlyWith (toolchain:
+    (rust-bin.selectLatestNightlyWith (
+      toolchain:
       toolchain.minimal.override {
-        extensions = [ "rustfmt" "rust-analyzer" ];
-      }))
+        extensions = [
+          "rustfmt"
+          "rust-analyzer"
+        ];
+      }
+    ))
   ];
 
   env = {


### PR DESCRIPTION
- [x] Following https://github.com/IntQuant/noita_entangled_worlds/pull/470#issue-4087419879

This PR update `nix/shell.nix`. I've found that the previous config do not work but after modifying the env to include `LD_LIBRARY_PATH` I've successfully got `noita-proxy` to compiles and runs.

This PR also add additional `devShells`
- `cross-ewext`
- `cross-noita-proxy`

which used by scripts within `nix/cross/build-*`. These devShells and scripts allow NixOS to cross-compile the project incrementally during development