### PR TITLE
Overridable settings path

### DIFF
--- a/noita-proxy/src/app.rs
+++ b/noita-proxy/src/app.rs
@@ -165,7 +165,10 @@ impl App {
     pub fn new(cc: &eframe::CreationContext<'_>, args: Args) -> Self {
         cc.egui_ctx.set_visuals(Visuals::dark());
         cc.egui_ctx.set_theme(ThemePreference::Dark);
-        let save_paths = SavePaths::new();
+        let save_paths = SavePaths::new_with_maybe_override(
+            args.settings_path.clone(),
+            args.save_state_path.clone(),
+        );
         let settings = save_paths.load_settings();
         let mut saved_state: AppSavedState = settings.app;
         let modmanager_settings: ModmanagerSettings = settings.modmanager;

--- a/noita-proxy/src/bookkeeping/save_paths.rs
+++ b/noita-proxy/src/bookkeeping/save_paths.rs
@@ -85,7 +85,9 @@ impl SavePaths {
                     .config_dir(),
             );
         }
-        let _ = fs::create_dir_all(&save_state_path);
+        if let Some(save_state_path_parent) = &save_state_path.parent() {
+            let _ = fs::create_dir_all(save_state_path_parent);
+        }
 
         info!("Settings path: {}", settings_path.display());
         info!("Save state path: {}", save_state_path.display());

--- a/noita-proxy/src/bookkeeping/save_paths.rs
+++ b/noita-proxy/src/bookkeeping/save_paths.rs
@@ -9,41 +9,92 @@ use tracing::{info, warn};
 
 use crate::Settings;
 
+const DEFAULT_SETTINGS_NAME: &str = "proxy.ron";
+const DEFAULT_SAVE_STATE_NAME: &str = "save_state";
+
+const PROJECT_DIRS_ORGANIZATION: &str = "quant";
+const PROJECT_DIRS_APPLICATION: &str = "entangledworlds";
+
 pub(crate) struct SavePaths {
     settings_path: PathBuf,
     pub save_state_path: PathBuf,
 }
 
 impl SavePaths {
-    pub fn new() -> Self {
-        if Self::settings_next_to_exe_path().exists() {
-            Self::new_next_to_exe()
-        } else if let Some(project_dirs) = Self::project_dirs() {
-            info!("Using 'system' paths to store things");
-            let me = Self {
-                settings_path: project_dirs.config_dir().join("proxy.ron"),
-                save_state_path: project_dirs.data_dir().join("save_state"),
-            };
-            info!("Settings path: {}", me.settings_path.display());
-            let _ = fs::create_dir_all(project_dirs.config_dir());
-            let _ = fs::create_dir_all(&me.save_state_path);
-            me
-        } else {
-            warn!("Failed to get project dirst!");
-            Self::new_next_to_exe()
+    pub fn new(settings_path: PathBuf, save_state_path: PathBuf) -> Self {
+        SavePaths {
+            settings_path,
+            save_state_path,
         }
     }
 
-    fn new_next_to_exe() -> Self {
-        info!("Using 'next to exe' path to store things");
-        Self {
-            settings_path: Self::settings_next_to_exe_path(),
-            save_state_path: Self::next_to_exe_path().join("save_state"),
+    pub fn new_with_maybe_override(
+        settings_path: Option<PathBuf>,
+        save_state_path: Option<PathBuf>,
+    ) -> SavePaths {
+        use Prefer::*;
+        enum Prefer {
+            Custom,
+            NextToExe,
+            ProjectDirs,
         }
+
+        let project_dirs = Self::project_dirs();
+        let settings_next_to_exe_path = Self::default_settings_next_to_exe_path();
+
+        let settings_prefer: Prefer;
+        let settings_path = if let Some(settings_path) = settings_path {
+            settings_prefer = Custom;
+            settings_path
+        } else if settings_next_to_exe_path.exists() {
+            settings_prefer = NextToExe;
+            settings_next_to_exe_path
+        } else if let Some(project_dirs) = &project_dirs {
+            settings_prefer = ProjectDirs;
+            project_dirs.config_dir().join(DEFAULT_SETTINGS_NAME)
+        } else {
+            warn!(
+                "There is no path override and failed to get project dirs. Falling back to 'next to exe' to store settings and save states."
+            );
+            settings_prefer = NextToExe;
+            settings_next_to_exe_path
+        };
+
+        let save_state_path = if let Some(save_state_path) = save_state_path {
+            save_state_path
+        } else {
+            let get_project_dirs_path = || {
+                project_dirs
+                    .as_ref()
+                    .expect("project_dirs is already checked to be some")
+                    .data_dir()
+                    .join(DEFAULT_SAVE_STATE_NAME)
+            };
+            match settings_prefer {
+                Custom if project_dirs.is_some() => get_project_dirs_path(),
+                Custom => Self::default_save_state_next_to_exe_path(),
+                ProjectDirs => get_project_dirs_path(),
+                NextToExe => Self::default_save_state_next_to_exe_path(),
+            }
+        };
+
+        if matches!(settings_prefer, ProjectDirs) {
+            let _ = fs::create_dir_all(
+                project_dirs
+                    .expect("project_dirs is already checked to be some")
+                    .config_dir(),
+            );
+        }
+        let _ = fs::create_dir_all(&save_state_path);
+
+        info!("Settings path: {}", settings_path.display());
+        info!("Save state path: {}", save_state_path.display());
+
+        Self::new(settings_path, save_state_path)
     }
 
     fn project_dirs() -> Option<ProjectDirs> {
-        ProjectDirs::from("", "quant", "entangledworlds")
+        ProjectDirs::from("", PROJECT_DIRS_ORGANIZATION, PROJECT_DIRS_APPLICATION)
     }
 
     fn next_to_exe_path() -> PathBuf {
@@ -52,12 +103,12 @@ impl SavePaths {
             .unwrap_or(".".into())
     }
 
-    fn settings_next_to_exe_path() -> PathBuf {
-        let base_path = std::env::current_exe()
-            .map(|p| p.parent().unwrap().to_path_buf())
-            .unwrap_or(".".into());
-        let config_name = "proxy.ron";
-        base_path.join(config_name)
+    fn default_settings_next_to_exe_path() -> PathBuf {
+        Self::next_to_exe_path().join(DEFAULT_SETTINGS_NAME)
+    }
+
+    fn default_save_state_next_to_exe_path() -> PathBuf {
+        Self::next_to_exe_path().join(DEFAULT_SAVE_STATE_NAME)
     }
 
     pub fn load_settings(&self) -> Settings {

--- a/noita-proxy/src/cli.rs
+++ b/noita-proxy/src/cli.rs
@@ -37,6 +37,14 @@ pub struct Args {
     #[argh(option)]
     pub language: Option<String>,
 
+    /// overrides the default settings file location
+    #[argh(option)]
+    pub settings_path: Option<PathBuf>,
+
+    /// overrides the default save state file location
+    #[argh(option)]
+    pub save_state_path: Option<PathBuf>,
+
     // Used internally.
     /// override lobby mode to use. Options: "Gog", "Steam".
     #[argh(option)]
@@ -75,7 +83,11 @@ fn cli_setup(
     AudioSettings,
     steamworks::LobbyType,
 ) {
-    let settings = SavePaths::new().load_settings();
+    let settings = SavePaths::new_with_maybe_override(
+        args.settings_path.clone(),
+        args.save_state_path.clone(),
+    )
+    .load_settings();
     let saved_state: AppSavedState = settings.app;
     let mut mod_manager: ModmanagerSettings = settings.modmanager;
     let appearance: PlayerAppearance = settings.color;


### PR DESCRIPTION
Add settings_path and save_state_path option to CLI which allows users to override the default paths. The previous path behavior is preserved. Also, other code improvements.

Possible future improvements:
- Check if path is valid.
- Unify other paths that the proxy uses and make them all configurable.