### PR TITLE
Path handling rewrite

### DIFF
--- a/noita-proxy/src/app.rs
+++ b/noita-proxy/src/app.rs
@@ -1254,9 +1254,9 @@ impl App {
                 }
                 ConnectedMenu::ProxyLog => {
                     if let Ok(s) = fs::read_to_string(if let Ok(path) = std::env::current_exe() {
-                        path.parent().unwrap().join("ew_log.txt")
+                        path.parent().unwrap().join(paths::DEFAULT_PROXY_LOG_NAME)
                     } else {
-                        "ew_log.txt".into()
+                        paths::DEFAULT_PROXY_LOG_NAME.into()
                     })
                         && s.len() > self.proxylog.len() {
                             self.proxylog = s

--- a/noita-proxy/src/app.rs
+++ b/noita-proxy/src/app.rs
@@ -11,13 +11,13 @@ use std::{
 
 use arboard::Clipboard;
 use image::{DynamicImage::ImageRgba8, RgbaImage};
-use mod_manager::{Modmanager, ModmanagerSettings};
+use mod_manager::Modmanager;
 use self_update::SelfUpdateManager;
 use serde::{Deserialize, Serialize};
 use steamworks::{LobbyId, SteamAPIInitError};
 use tangled::{Peer, Reliability};
 use tokio::time;
-use tracing::info;
+use tracing::{error, info};
 use unic_langid::LanguageIdentifier;
 
 use eframe::egui::{
@@ -28,7 +28,6 @@ use eframe::egui::{
 
 use crate::{
     AudioSettings, DefaultSettings, GameSettings, ImageMap, NetManStopOnDrop, PlayerAppearance,
-    Settings,
     bookkeeping::{
         mod_manager,
         noita_launcher::{LaunchTokenResult, NoitaLauncher},
@@ -37,17 +36,19 @@ use crate::{
         save_state::SaveState,
         self_restart::SelfRestarter,
         self_update,
+        settings::Settings,
     },
     cli::Args,
     lang::{set_current_locale, tr},
     lobby_code::{LobbyCode, LobbyError, LobbyKind},
     net::{
-        NetManager, NetManagerInit, RunInfo,
+        NetManager, NetManagerInit, NetManagerPaths, RunInfo,
         messages::NetMsg,
         omni::{OmniPeerId, PeerVariant},
         steam_networking,
     },
-    player_cosmetics::{PlayerPngDesc, display_player_skin, player_path},
+    paths::{self, Paths},
+    player_cosmetics::{PlayerPngDesc, display_player_skin},
     steam_helper,
     util::steam_helper::LobbyExtraData,
 };
@@ -169,11 +170,19 @@ impl App {
             args.save_state_path.clone(),
         );
         let settings = save_paths.load_settings();
-        let mut saved_state: AppSavedState = settings.app;
-        let modmanager_settings: ModmanagerSettings = settings.modmanager;
-        let appearance: PlayerAppearance = settings.color;
-        let audio: AudioSettings = settings.audio;
+        let Settings {
+            color: appearance,
+            app: mut saved_state,
+            audio,
+            mut paths,
+        } = settings;
+        paths.proxy_settings = Some(save_paths.settings_path.clone());
+        paths.proxy_save_state = Some(save_paths.save_state_path.clone());
         saved_state.times_started += 1;
+
+        if paths.noita_exe.is_some() {
+            paths::realize_noita_paths_from_noita_exe(&mut paths);
+        }
 
         info!("Setting fonts...");
         Self::set_fonts(&cc.egui_ctx);
@@ -215,8 +224,9 @@ impl App {
             .set_zoom_factor(args.ui_zoom_factor.unwrap_or(default_zoom_factor));
         info!("Creating the app...");
         let run_save_state = SaveState::new(&save_paths.save_state_path);
-        let path = player_path(modmanager_settings.mod_path());
-        let player_image = if path.exists() {
+        let player_image = if let Some(path) = &paths.noita_quantew_player_spritesheet
+            && path.exists()
+        {
             image::open(path)
                 .unwrap_or(ImageRgba8(RgbaImage::new(20, 20)))
                 .crop(1, 1, 7, 16)
@@ -231,7 +241,6 @@ impl App {
             modmanager: Modmanager::default(),
             steam_state,
             app_saved_state: saved_state,
-            modmanager_settings,
             self_update: SelfUpdateManager::new(),
             lobby_id_field: "".to_string(),
             args,
@@ -252,8 +261,8 @@ impl App {
             noitalog_number: 0,
             noitalog: Vec::new(),
             proxylog: String::new(),
-            save_paths,
             clipboard: Clipboard::new().ok(),
+            paths,
         };
 
         if let Some(connect_to) = me.args.auto_connect_to {
@@ -267,19 +276,24 @@ impl App {
         let mut audio = self.audio.clone();
         audio.input_devices.clear();
         audio.output_devices.clear();
-        self.save_paths.save_settings(Settings {
+
+        let result = Settings {
             color: self.appearance.clone(),
             app: self.app_saved_state.clone(),
-            modmanager: self.modmanager_settings.clone(),
+            paths: self.paths.clone(),
             audio,
-        });
+        }
+        .save(self.paths.proxy_settings());
+        match result {
+            Ok(()) => (),
+            Err(e) => error!("Failed to save settings: {e}"),
+        }
     }
 
     fn get_netman_init(&self) -> NetManagerInit {
         let my_nickname = self.nickname();
-        let mod_path = self.modmanager_settings.mod_path();
         let mut cosmetics = self.appearance.cosmetics;
-        if let Some(path) = &self.modmanager_settings.game_save_path {
+        if let Some(path) = &self.paths.noita_save {
             let flags = path.join("save00/persistent/flags");
             let hat = flags.join("secret_hat").exists();
             let amulet = flags.join("secret_amulet").exists();
@@ -300,13 +314,13 @@ impl App {
             21251
         };
 
+        let paths = NetManagerPaths::try_from_paths(&self.paths).expect("necessary paths are some");
+
         NetManagerInit {
             my_nickname,
             save_state: self.run_save_state.clone(),
             cosmetics,
-            mod_path,
-            player_path: player_path(self.modmanager_settings.mod_path()),
-            modmanager_settings: self.modmanager_settings.clone(),
+            paths,
             player_png_desc: PlayerPngDesc {
                 cosmetics: cosmetics.into(),
                 colors: self.appearance.player_color,
@@ -340,7 +354,7 @@ impl App {
         self.state = AppState::ConnectedLobby {
             netman: NetManStopOnDrop(netman, Some(handle)),
             noita_launcher: NoitaLauncher::new(
-                &self.modmanager_settings.game_exe_path,
+                self.paths.noita_exe(),
                 self.args.launch_cmd.as_deref(),
                 self.args.run_noita_with_gdb,
                 self.steam_state.as_mut().ok(),
@@ -358,7 +372,10 @@ impl App {
             self.audio.clone(),
         );
         self.set_netman_settings(&netman);
-        self.change_state_to_netman(netman, player_path(self.modmanager_settings.mod_path()));
+        self.change_state_to_netman(
+            netman,
+            self.paths.noita_quantew_player_spritesheet().clone(),
+        );
     }
 
     fn set_netman_settings(&mut self, netman: &Arc<NetManager>) {
@@ -376,7 +393,8 @@ impl App {
         } else {
             info!("Using constant seed: {}", settings.seed);
         }
-        settings.progress = self.modmanager_settings.get_progress().unwrap_or_default();
+        settings.progress =
+            mod_manager::get_progress(self.paths.noita_save.as_deref()).unwrap_or_default();
         *netman.pending_settings.lock().unwrap() = settings.clone();
     }
 
@@ -391,7 +409,10 @@ impl App {
             self.get_netman_init(),
             self.audio.clone(),
         );
-        self.change_state_to_netman(netman, player_path(self.modmanager_settings.mod_path()));
+        self.change_state_to_netman(
+            netman,
+            self.paths.noita_quantew_player_spritesheet().clone(),
+        );
     }
 
     fn start_steam_host(&mut self) {
@@ -417,7 +438,10 @@ impl App {
             self.audio.clone(),
         );
         self.set_netman_settings(&netman);
-        self.change_state_to_netman(netman, player_path(self.modmanager_settings.mod_path()));
+        self.change_state_to_netman(
+            netman,
+            self.paths.noita_quantew_player_spritesheet().clone(),
+        );
     }
 
     fn make_lobby_extra_data(&self) -> LobbyExtraData {
@@ -449,7 +473,10 @@ impl App {
             self.get_netman_init(),
             self.audio.clone(),
         );
-        self.change_state_to_netman(netman, player_path(self.modmanager_settings.mod_path()));
+        self.change_state_to_netman(
+            netman,
+            self.paths.noita_quantew_player_spritesheet().clone(),
+        );
     }
 
     fn connect_screen(&mut self, ctx: &Context) {
@@ -694,7 +721,7 @@ impl App {
         let secret_active = ui.input(|i| i.modifiers.ctrl && i.key_down(Key::D));
         if secret_active && ui.button("reset all data").clicked() {
             self.app_saved_state = Default::default();
-            self.modmanager_settings = Default::default();
+            self.paths = Default::default();
             self.state = AppState::LangPick;
         }
     }
@@ -808,7 +835,7 @@ impl App {
             tr("connect_settings_random_ports"),
         );
         if self.player_image.width() == 1 {
-            self.player_image = image::open(player_path(self.modmanager_settings.mod_path()))
+            self.player_image = image::open(self.paths.noita_quantew_player_spritesheet())
                 .unwrap_or(ImageRgba8(RgbaImage::new(20, 20)))
                 .crop(1, 1, 7, 16)
                 .into_rgba8();
@@ -816,7 +843,7 @@ impl App {
         ui.add_space(20.0);
         self.appearance.mina_color_picker(
             ui,
-            self.modmanager_settings.game_save_path.clone(),
+            self.paths.noita_save.clone(),
             self.player_image.clone(),
         );
     }
@@ -1022,7 +1049,7 @@ impl App {
                 }
                 ui.separator();
             }
-            if let Some(game) = self.modmanager_settings.game_exe_path.parent()
+            if let Some(game) = self.paths.noita_exe().parent()
                 && let Ok(s) = fs::read_to_string(game.join("logger.txt")) {
                     let l = self.noitalog.len();
                     if l != 0 && s.len() >= self.noitalog[l - 1].len() {
@@ -1054,7 +1081,7 @@ impl App {
                     }
                     self.appearance.mina_color_picker(
                         ui,
-                        self.modmanager_settings.game_save_path.clone(),
+                        self.paths.noita_save.clone(),
                         self.player_image.clone(),
                     );
                     ui.add_space(15.0);
@@ -1062,7 +1089,7 @@ impl App {
                         if ui.button("save colors").clicked() {
                             let desc = self
                                 .appearance
-                                .create_png_desc(self.modmanager_settings.game_save_path.clone());
+                                .create_png_desc(self.paths.noita_save.clone());
                             netman.new_desc(desc, self.player_image.clone());
                             *netman.new_desc.lock().unwrap() = Some(desc);
                         };
@@ -1309,7 +1336,7 @@ impl eframe::App for App {
                         self.modmanager.update(
                             ctx,
                             ui,
-                            &mut self.modmanager_settings,
+                            &mut self.paths,
                             self.steam_state.as_mut().ok(),
                             &self.args,
                         )

--- a/noita-proxy/src/app.rs
+++ b/noita-proxy/src/app.rs
@@ -131,7 +131,6 @@ pub struct App {
     steam_state: Result<steam_helper::SteamState, SteamAPIInitError>,
     app_saved_state: AppSavedState,
     run_save_state: SaveState,
-    modmanager_settings: ModmanagerSettings,
     self_update: SelfUpdateManager,
     lobby_id_field: String,
     args: Args,
@@ -152,8 +151,8 @@ pub struct App {
     noitalog_number: usize,
     noitalog: Vec<String>,
     proxylog: String,
-    save_paths: SavePaths,
     clipboard: Option<Clipboard>,
+    paths: Paths,
 }
 
 impl Drop for App {

--- a/noita-proxy/src/bookkeeping/mod.rs
+++ b/noita-proxy/src/bookkeeping/mod.rs
@@ -6,3 +6,4 @@ pub mod save_paths;
 pub mod save_state;
 pub mod self_restart;
 pub mod self_update;
+pub mod settings;

--- a/noita-proxy/src/bookkeeping/mod_manager.rs
+++ b/noita-proxy/src/bookkeeping/mod_manager.rs
@@ -18,6 +18,7 @@ use tracing::{error, info, warn};
 
 use crate::{
     lang::tr,
+    paths::{self, Paths},
     releases::{Downloader, ReleasesError, Version, get_release_by_tag},
     steam_helper::SteamState,
 };
@@ -52,24 +53,35 @@ impl Modmanager {
         &mut self,
         ctx: &Context,
         ui: &mut Ui,
-        settings: &mut ModmanagerSettings,
+        paths: &mut Paths,
         steam_state: Option<&mut SteamState>,
         args: &Args,
     ) {
         if let State::JustStarted = self.state {
             if let Some(path) = &args.exe_path {
-                if check_path_valid(path) {
-                    settings.game_exe_path = path.to_path_buf();
+                if check_noita_exe_path_valid(path) {
+                    paths.noita_exe = Some(path.to_path_buf());
+                    paths::realize_noita_paths_from_noita_exe(paths);
                     info!("Path from command line is valid, checking mod now");
                     self.state = State::PreCheckMod;
+                } else {
+                    panic!(
+                        "Exe path {} received from command line is invalid",
+                        path.display()
+                    );
                 }
-            } else if check_path_valid(&settings.game_exe_path) {
+            } else if let Some(noita_exe) = &paths.noita_exe
+                && check_noita_exe_path_valid(noita_exe)
+            {
                 info!("Path is valid, checking mod now");
+                paths::realize_noita_paths_from_noita_exe(paths);
                 self.state = State::PreCheckMod;
             } else {
-                settings.try_find_game_path(steam_state);
-                let could_find_automatically = check_path_valid(&settings.game_exe_path);
-                if could_find_automatically {
+                try_find_game_path(paths, steam_state.as_deref());
+                if let Some(noita_exe) = &paths.noita_exe
+                    && check_noita_exe_path_valid(noita_exe)
+                {
+                    paths::realize_noita_paths_from_noita_exe(paths);
                     self.state = State::IsAutomaticPathOk;
                 } else {
                     self.select_noita_file();
@@ -81,7 +93,7 @@ impl Modmanager {
             State::JustStarted => unreachable!(),
             State::IsAutomaticPathOk => {
                 ui.heading(tr("modman_found_automatically"));
-                ui.label(settings.game_exe_path.display().to_string());
+                ui.label(paths.noita_exe().display().to_string());
                 if ui.button(tr("modman_use_this")).clicked() {
                     self.state = State::PreCheckMod;
                     ctx.request_repaint();
@@ -97,10 +109,11 @@ impl Modmanager {
             State::SelectPath(promise) => {
                 match promise.ready() {
                     Some(Ok(path)) => {
-                        settings.game_exe_path = path.to_path_buf();
-                        if !check_path_valid(&settings.game_exe_path) {
+                        if !check_noita_exe_path_valid(path) {
                             self.state = State::InvalidPath;
                         } else {
+                            paths.noita_exe = Some(path.to_path_buf());
+                            paths::realize_noita_paths_from_noita_exe(paths);
                             self.state = State::PreCheckMod;
                         }
                     }
@@ -118,9 +131,9 @@ impl Modmanager {
                 }
             }
             State::PreCheckMod => {
-                settings.try_find_save_path();
+                try_find_save_path(paths);
 
-                if let Some(path) = &settings.game_save_path {
+                if let Some(path) = &paths.noita_save {
                     info!("Trying to enable mod: {:?}", enable_mod(path));
                 }
                 ui.label("Will check mod install now...");
@@ -129,10 +142,10 @@ impl Modmanager {
             }
             State::CheckMod => {
                 ctx.request_repaint();
-                let mod_path = settings.mod_path();
+                let mod_path = paths.noita_quantew_install();
                 info!("Mod path: {}", mod_path.display());
 
-                self.state = match is_mod_ok(&mod_path).wrap_err("Failed to check if mod is ok") {
+                self.state = match is_mod_ok(mod_path).wrap_err("Failed to check if mod is ok") {
                     Ok(true) => State::Done,
                     Ok(false) => State::ConfirmInstall,
                     Err(err) => {
@@ -142,7 +155,7 @@ impl Modmanager {
                 }
             }
             State::ConfirmInstall => {
-                let mod_path = settings.mod_path();
+                let mod_path = paths.noita_quantew_install();
                 ui.label(tr("modman_will_install_to"));
                 ui.label(mod_path.display().to_string());
                 ui.horizontal(|ui| {
@@ -184,12 +197,12 @@ impl Modmanager {
                         Ok(downloader) => {
                             if downloader.ready().is_some() {
                                 let path = downloader.path().to_path_buf();
-                                let directory = settings.mod_path();
+                                let directory = paths.noita_quantew_install().clone();
                                 match downloader.into_ready() {
                                     Ok(_) => {
                                         let promise: Promise<Result<(), ReleasesError>> =
                                             Promise::spawn_thread("unpack", move || {
-                                                extract_and_remove_zip(path, directory)
+                                                extract_and_remove_zip(&path, &directory)
                                             });
                                         info!("Switching to UnpackMod state");
                                         self.state = State::UnpackMod(promise);
@@ -370,13 +383,13 @@ fn mod_downloader_for(
         .wrap_err("Failed to download mod")
 }
 
-fn extract_and_remove_zip(zip_file: PathBuf, extract_to: PathBuf) -> Result<(), ReleasesError> {
-    extract_zip(&zip_file, extract_to)?;
-    fs::remove_file(&zip_file).ok();
+fn extract_and_remove_zip(zip_file: &Path, extract_to: &Path) -> Result<(), ReleasesError> {
+    extract_zip(zip_file, extract_to)?;
+    fs::remove_file(zip_file).ok();
     Ok(())
 }
 
-fn extract_zip(zip_file: &Path, extract_to: PathBuf) -> Result<(), eyre::Error> {
+fn extract_zip(zip_file: &Path, extract_to: &Path) -> Result<(), eyre::Error> {
     let zip_file = zip_file.canonicalize().unwrap_or(zip_file.to_path_buf());
     let reader = File::open(&zip_file)
         .wrap_err_with(|| format!("Failed to open zip file: {}", zip_file.display()))?;
@@ -387,7 +400,7 @@ fn extract_zip(zip_file: &Path, extract_to: PathBuf) -> Result<(), eyre::Error> 
         )
     })?;
     info!("Extracting zip file");
-    zip.extract(&extract_to)
+    zip.extract(extract_to)
         .wrap_err_with(|| format!("Failed to extract zip to: {}", extract_to.display()))?;
     info!("Zip file extracted");
     Ok(())
@@ -420,7 +433,7 @@ fn is_mod_ok(mod_path: &Path) -> eyre::Result<bool> {
     Ok(true)
 }
 
-fn check_path_valid(game_path: &Path) -> bool {
+fn check_noita_exe_path_valid(game_path: &Path) -> bool {
     game_path.ends_with("noita.exe") && game_path.exists()
 }
 

--- a/noita-proxy/src/bookkeeping/mod_manager.rs
+++ b/noita-proxy/src/bookkeeping/mod_manager.rs
@@ -47,96 +47,6 @@ pub struct Modmanager {
     state: State,
 }
 
-#[derive(Debug, Serialize, Deserialize, Default, Clone)]
-#[serde(default)]
-pub struct ModmanagerSettings {
-    pub game_exe_path: PathBuf,
-    pub game_save_path: Option<PathBuf>,
-}
-
-impl ModmanagerSettings {
-    pub fn try_find_game_path(&mut self, steam_state: Option<&mut SteamState>) {
-        info!("Trying to find game path");
-        if let Some(state) = steam_state {
-            let apps = state.client.apps();
-            let app_id = AppId::from(881100);
-            if apps.is_app_installed(app_id) {
-                let app_install_dir = apps.app_install_dir(app_id);
-                self.game_exe_path = PathBuf::from(app_install_dir).join("noita.exe");
-                info!(
-                    "Found game path with steam: {}",
-                    self.game_exe_path.display()
-                )
-            } else {
-                info!("App not installed");
-            }
-        }
-    }
-
-    pub fn try_find_save_path(&mut self) {
-        if cfg!(target_os = "windows") {
-            // Noita uses AppData folder instead of %AppData%
-            let appdata_path = PathBuf::from(
-                env::var_os("USERPROFILE").expect("homepath to be defined on windows"),
-            )
-            .join("AppData");
-            info!("Appdata path: {}", appdata_path.display());
-            let save_path = appdata_path.join("LocalLow/Nolla_Games_Noita/");
-            info!("Trying save path: {}", save_path.display());
-            if save_path.exists() {
-                info!("Save path exists");
-                self.game_save_path = Some(save_path);
-            } else {
-                info!("Save path does not exist");
-            }
-        }
-        if cfg!(target_os = "linux") {
-            let mut save_path = self.game_exe_path.clone();
-            // Reach steamapps/
-            save_path.pop();
-            save_path.pop();
-            save_path.pop();
-            save_path.push(
-                "compatdata/881100/pfx/drive_c/users/steamuser/AppData/LocalLow/Nolla_Games_Noita/",
-            );
-            info!("Probable save_path: {}", save_path.display());
-            if save_path.exists() {
-                info!("Save path exists");
-                self.game_save_path = Some(save_path);
-            }
-        }
-
-        match &self.game_save_path {
-            Some(path) => info!("Found game save path: {}", path.display()),
-            None => warn!("Could not find game save path"),
-        }
-    }
-
-    pub fn mod_path(&self) -> PathBuf {
-        let mut path = self.game_exe_path.clone();
-        path.pop();
-        path.push("mods");
-        path.push("quant.ew");
-        path
-    }
-
-    pub fn get_progress(&self) -> Option<Vec<String>> {
-        let flags_path = self
-            .game_save_path
-            .as_ref()?
-            .join("save00/persistent/flags/");
-        Some(
-            fs::read_dir(&flags_path)
-                .inspect_err(|e| warn!("Could not read progress: read_dir failed: {e}"))
-                .ok()?
-                .filter_map(|entry| entry.ok())
-                .filter_map(|entry| entry.file_name().into_string().ok())
-                .collect(),
-        )
-        .inspect(|progress: &Vec<String>| info!("Found {} progress entries", progress.len()))
-    }
-}
-
 impl Modmanager {
     pub fn update(
         &mut self,
@@ -357,6 +267,78 @@ impl Modmanager {
     pub fn is_done(&self) -> bool {
         matches!(self.state, State::Done)
     }
+}
+
+pub fn try_find_game_path(paths: &mut Paths, steam_state: Option<&SteamState>) {
+    info!("Trying to find game path");
+    if let Some(state) = steam_state {
+        let apps = state.client.apps();
+        let app_id = AppId::from(881100);
+        if apps.is_app_installed(app_id) {
+            let app_install_dir = apps.app_install_dir(app_id);
+            paths.noita_install = Some(app_install_dir.into());
+            let noita_install = paths.noita_install();
+            paths.noita_exe = Some(PathBuf::from(noita_install).join("noita.exe"));
+            info!(
+                "Found game path with steam: {}",
+                paths.noita_exe().display()
+            )
+        } else {
+            info!("App not installed");
+        }
+    }
+}
+
+pub fn try_find_save_path(paths: &mut Paths) {
+    if cfg!(target_os = "windows") {
+        // Noita uses AppData folder instead of %AppData%
+        let appdata_path =
+            PathBuf::from(env::var_os("USERPROFILE").expect("homepath to be defined on windows"))
+                .join("AppData");
+        info!("Appdata path: {}", appdata_path.display());
+        let save_path = appdata_path.join("LocalLow/Nolla_Games_Noita/");
+        info!("Trying save path: {}", save_path.display());
+        if save_path.exists() {
+            info!("Save path exists");
+            paths.noita_save = Some(save_path);
+        } else {
+            info!("Save path does not exist");
+        }
+    }
+    if cfg!(target_os = "linux") {
+        let Some(mut save_path) = paths.noita_install.clone() else {
+            warn!("noita_install path is None");
+            return;
+        };
+        info!("Assuming noita_install path is in steam");
+        // Reach steamapps/
+        save_path.pop();
+        save_path.pop();
+        save_path.push(paths::STEAM_COMPATDATA_NOITA_SAVE);
+        info!("Probable save_path: {}", save_path.display());
+        if save_path.exists() {
+            info!("Save path exists");
+            paths.noita_save = Some(save_path);
+        }
+    }
+
+    match &paths.noita_save {
+        Some(path) => info!("Found game save path: {}", path.display()),
+        None => warn!("Could not find game save path"),
+    }
+}
+
+pub fn get_progress(noita_save: Option<&Path>) -> Option<Vec<String>> {
+    let flags_path = noita_save?.join("save00/persistent/flags/");
+    Some(
+        fs::read_dir(&flags_path)
+            .inspect_err(|e| warn!("Could not read progress: read_dir failed: {e}"))
+            .ok()?
+            .filter_map(|entry| entry.ok())
+            .filter_map(|entry| entry.file_name().into_string().ok())
+            .collect(),
+    )
+    .inspect(|progress: &Vec<String>| info!("Found {} progress entries", progress.len()))
 }
 
 fn mod_downloader_for(

--- a/noita-proxy/src/bookkeeping/save_paths.rs
+++ b/noita-proxy/src/bookkeeping/save_paths.rs
@@ -88,20 +88,21 @@ impl SavePaths {
     }
 
     pub fn load_settings(&self) -> Settings {
-        if let Ok(mut file) = File::open(&self.settings_path) {
-            let mut s = String::new();
-            let _ = file.read_to_string(&mut s);
-            ron::from_str::<Settings>(&s).unwrap_or_default()
-        } else {
-            info!("Failed to load settings file, returing default settings");
-            Settings::default()
+        match Settings::load(&self.settings_path) {
+            Ok(settings) => settings,
+            Err(e) => {
+                warn!("Failed to load settings: {e}");
+                info!("Using default settings");
+                Settings::default()
+            }
         }
     }
 
+    #[expect(unused, reason = "Saving is done through Settings directly for now")]
     pub fn save_settings(&self, settings: Settings) {
-        let settings = ron::to_string(&settings).unwrap();
-        if let Ok(mut file) = File::create(&self.settings_path) {
-            file.write_all(settings.as_bytes()).unwrap();
+        match settings.save(&self.settings_path) {
+            Ok(()) => (),
+            Err(e) => error!("Failed to save settings: {e}"),
         }
     }
 }

--- a/noita-proxy/src/bookkeeping/save_paths.rs
+++ b/noita-proxy/src/bookkeeping/save_paths.rs
@@ -1,22 +1,13 @@
-use std::{
-    fs::{self, File},
-    io::{Read, Write},
-    path::PathBuf,
-};
+use std::fs;
+use std::path::PathBuf;
 
-use directories::ProjectDirs;
-use tracing::{info, warn};
+use tracing::{error, info, warn};
 
-use crate::Settings;
+use crate::{bookkeeping::settings::Settings, paths};
 
-const DEFAULT_SETTINGS_NAME: &str = "proxy.ron";
-const DEFAULT_SAVE_STATE_NAME: &str = "save_state";
-
-const PROJECT_DIRS_ORGANIZATION: &str = "quant";
-const PROJECT_DIRS_APPLICATION: &str = "entangledworlds";
-
+/// Paths that are saved and loaded by the proxy
 pub(crate) struct SavePaths {
-    settings_path: PathBuf,
+    pub settings_path: PathBuf,
     pub save_state_path: PathBuf,
 }
 
@@ -39,8 +30,9 @@ impl SavePaths {
             ProjectDirs,
         }
 
-        let project_dirs = Self::project_dirs();
-        let settings_next_to_exe_path = Self::default_settings_next_to_exe_path();
+        let project_dirs = paths::project_dirs();
+        let proxy_exe_dir = paths::proxy_exe_dir();
+        let settings_next_to_exe_path = proxy_exe_dir.join(paths::DEFAULT_SETTINGS_NAME);
 
         let settings_prefer: Prefer;
         let settings_path = if let Some(settings_path) = settings_path {
@@ -51,7 +43,7 @@ impl SavePaths {
             settings_next_to_exe_path
         } else if let Some(project_dirs) = &project_dirs {
             settings_prefer = ProjectDirs;
-            project_dirs.config_dir().join(DEFAULT_SETTINGS_NAME)
+            project_dirs.config_dir().join(paths::DEFAULT_SETTINGS_NAME)
         } else {
             warn!(
                 "There is no path override and failed to get project dirs. Falling back to 'next to exe' to store settings and save states."
@@ -68,13 +60,13 @@ impl SavePaths {
                     .as_ref()
                     .expect("project_dirs is already checked to be some")
                     .data_dir()
-                    .join(DEFAULT_SAVE_STATE_NAME)
+                    .join(paths::DEFAULT_SAVE_STATE_NAME)
             };
             match settings_prefer {
                 Custom if project_dirs.is_some() => get_project_dirs_path(),
-                Custom => Self::default_save_state_next_to_exe_path(),
+                Custom => proxy_exe_dir.join(paths::DEFAULT_SAVE_STATE_NAME),
                 ProjectDirs => get_project_dirs_path(),
-                NextToExe => Self::default_save_state_next_to_exe_path(),
+                NextToExe => proxy_exe_dir.join(paths::DEFAULT_SAVE_STATE_NAME),
             }
         };
 
@@ -93,24 +85,6 @@ impl SavePaths {
         info!("Save state path: {}", save_state_path.display());
 
         Self::new(settings_path, save_state_path)
-    }
-
-    fn project_dirs() -> Option<ProjectDirs> {
-        ProjectDirs::from("", PROJECT_DIRS_ORGANIZATION, PROJECT_DIRS_APPLICATION)
-    }
-
-    fn next_to_exe_path() -> PathBuf {
-        std::env::current_exe()
-            .map(|p| p.parent().unwrap().to_path_buf())
-            .unwrap_or(".".into())
-    }
-
-    fn default_settings_next_to_exe_path() -> PathBuf {
-        Self::next_to_exe_path().join(DEFAULT_SETTINGS_NAME)
-    }
-
-    fn default_save_state_next_to_exe_path() -> PathBuf {
-        Self::next_to_exe_path().join(DEFAULT_SAVE_STATE_NAME)
     }
 
     pub fn load_settings(&self) -> Settings {

--- a/noita-proxy/src/bookkeeping/save_paths.rs
+++ b/noita-proxy/src/bookkeeping/save_paths.rs
@@ -32,7 +32,7 @@ impl SavePaths {
 
         let project_dirs = paths::project_dirs();
         let proxy_exe_dir = paths::proxy_exe_dir();
-        let settings_next_to_exe_path = proxy_exe_dir.join(paths::DEFAULT_SETTINGS_NAME);
+        let settings_next_to_exe_path = proxy_exe_dir.join(paths::DEFAULT_PROXY_SETTINGS_NAME);
 
         let settings_prefer: Prefer;
         let settings_path = if let Some(settings_path) = settings_path {
@@ -43,7 +43,9 @@ impl SavePaths {
             settings_next_to_exe_path
         } else if let Some(project_dirs) = &project_dirs {
             settings_prefer = ProjectDirs;
-            project_dirs.config_dir().join(paths::DEFAULT_SETTINGS_NAME)
+            project_dirs
+                .config_dir()
+                .join(paths::DEFAULT_PROXY_SETTINGS_NAME)
         } else {
             warn!(
                 "There is no path override and failed to get project dirs. Falling back to 'next to exe' to store settings and save states."
@@ -60,13 +62,13 @@ impl SavePaths {
                     .as_ref()
                     .expect("project_dirs is already checked to be some")
                     .data_dir()
-                    .join(paths::DEFAULT_SAVE_STATE_NAME)
+                    .join(paths::DEFAULT_PROXY_SAVE_STATE_NAME)
             };
             match settings_prefer {
                 Custom if project_dirs.is_some() => get_project_dirs_path(),
-                Custom => proxy_exe_dir.join(paths::DEFAULT_SAVE_STATE_NAME),
+                Custom => proxy_exe_dir.join(paths::DEFAULT_PROXY_SAVE_STATE_NAME),
                 ProjectDirs => get_project_dirs_path(),
-                NextToExe => proxy_exe_dir.join(paths::DEFAULT_SAVE_STATE_NAME),
+                NextToExe => proxy_exe_dir.join(paths::DEFAULT_PROXY_SAVE_STATE_NAME),
             }
         };
 

--- a/noita-proxy/src/bookkeeping/settings.rs
+++ b/noita-proxy/src/bookkeeping/settings.rs
@@ -1,0 +1,36 @@
+use std::fs::File;
+use std::io::{self, Read, Write};
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    app::AppSavedState, audio_settings::AudioSettings, paths::Paths,
+    player_settings::PlayerAppearance,
+};
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+#[serde(default)]
+pub struct Settings {
+    pub color: PlayerAppearance,
+    pub app: AppSavedState,
+    pub audio: AudioSettings,
+    pub paths: Paths,
+}
+
+impl Settings {
+    pub fn load(path: &Path) -> io::Result<Settings> {
+        let mut file = File::open(path)?;
+        let mut s = String::new();
+        let _ = file.read_to_string(&mut s);
+        let settings = ron::from_str::<Settings>(&s).unwrap_or_default();
+        Ok(settings)
+    }
+
+    pub fn save(&self, path: &Path) -> io::Result<()> {
+        let settings = ron::to_string(&self).unwrap();
+        let mut file = File::create(path)?;
+        file.write_all(settings.as_bytes())?;
+        Ok(())
+    }
+}

--- a/noita-proxy/src/cli.rs
+++ b/noita-proxy/src/cli.rs
@@ -4,13 +4,13 @@ use argh::{FromArgValue, FromArgs};
 use tangled::Peer;
 
 use crate::{
-    AppSavedState, AudioSettings, PlayerAppearance,
-    bookkeeping::{save_paths::SavePaths, save_state::SaveState},
+    AudioSettings,
+    bookkeeping::{save_paths::SavePaths, save_state::SaveState, settings::Settings},
     lobby_code::{LobbyCode, LobbyKind},
-    mod_manager::ModmanagerSettings,
-    net::{NetManager, NetManagerInit, omni::PeerVariant, steam_networking},
+    mod_manager,
+    net::{NetManager, NetManagerInit, NetManagerPaths, omni::PeerVariant, steam_networking},
+    paths,
     player_cosmetics::PlayerPngDesc,
-    player_cosmetics::player_path,
     steam_helper,
     util::steam_helper::LobbyExtraData,
 };
@@ -83,36 +83,34 @@ fn cli_setup(
     AudioSettings,
     steamworks::LobbyType,
 ) {
-    let settings = SavePaths::new_with_maybe_override(
+    let save_paths = SavePaths::new_with_maybe_override(
         args.settings_path.clone(),
         args.save_state_path.clone(),
-    )
-    .load_settings();
-    let saved_state: AppSavedState = settings.app;
-    let mut mod_manager: ModmanagerSettings = settings.modmanager;
-    let appearance: PlayerAppearance = settings.color;
-    let audio: AudioSettings = settings.audio;
+    );
+    let settings = save_paths.load_settings();
+    let Settings {
+        color: appearance,
+        app: saved_state,
+        audio,
+        mut paths,
+    } = settings;
     let mut state = steam_helper::SteamState::new(saved_state.spacewars).ok();
     let my_nickname = saved_state
         .nickname
         .unwrap_or("no nickname found".to_string());
 
     if let Some(state) = &mut state {
-        mod_manager.try_find_game_path(Some(state));
+        mod_manager::try_find_game_path(&mut paths, Some(state));
     } else if let Some(p) = args.exe_path {
-        mod_manager.game_exe_path = p
+        paths.noita_exe = Some(p);
     } else {
-        println!("needs game exe path if you want to join as host")
+        panic!("noita.exe is not provided and can't find it in settings.");
     }
-    mod_manager.try_find_save_path();
-    let run_save_state = if let Ok(path) = std::env::current_exe() {
-        SaveState::new(path.parent().unwrap().join("save_state"))
-    } else {
-        SaveState::new("./save_state/")
-    };
-    let player_path = player_path(mod_manager.mod_path());
+    paths::realize_noita_paths_from_noita_exe(&mut paths);
+    mod_manager::try_find_save_path(&mut paths);
+    let run_save_state = SaveState::new(save_paths.save_state_path);
     let mut cosmetics = (false, false, false);
-    if let Some(path) = &mod_manager.game_save_path {
+    if let Some(path) = &paths.noita_save {
         let flags = path.join("save00/persistent/flags");
         let hat = flags.join("secret_hat").exists();
         let amulet = flags.join("secret_amulet").exists();
@@ -127,13 +125,13 @@ fn cli_setup(
             cosmetics.2 = false
         }
     }
+    let paths =
+        NetManagerPaths::try_from_paths(&paths).expect("necessary paths for networking are some");
     let netmaninit = NetManagerInit {
         my_nickname,
         save_state: run_save_state,
         cosmetics,
-        mod_path: mod_manager.mod_path(),
-        player_path,
-        modmanager_settings: mod_manager,
+        paths,
         player_png_desc: PlayerPngDesc {
             cosmetics: cosmetics.into(),
             colors: appearance.player_color,
@@ -178,7 +176,7 @@ pub fn connect_cli(lobby: String, args: Args) {
         println!("no steam");
         exit(1)
     };
-    let player_path = netmaninit.player_path.clone();
+    let player_path = netmaninit.paths.noita_quantew_player_spritesheet.clone();
     let netman = NetManager::new(variant, netmaninit, audio);
     netman.start_inner(player_path, Some(kind)).unwrap();
 }
@@ -206,7 +204,7 @@ pub fn host_cli(bind_addr: Option<SocketAddr>, args: Args) {
         println!("no steam");
         exit(1)
     };
-    let player_path = netmaninit.player_path.clone();
+    let player_path = netmaninit.paths.noita_quantew_player_spritesheet.clone();
     let netman = NetManager::new(variant, netmaninit, audio);
     netman.start_inner(player_path, Some(kind)).unwrap();
 }

--- a/noita-proxy/src/lib.rs
+++ b/noita-proxy/src/lib.rs
@@ -23,6 +23,7 @@ use serde::{Deserialize, Serialize};
 mod bookkeeping;
 mod lobby_code;
 pub mod net;
+pub mod paths;
 mod player_cosmetics;
 mod util;
 

--- a/noita-proxy/src/lib.rs
+++ b/noita-proxy/src/lib.rs
@@ -8,17 +8,13 @@ pub use app::App;
 pub use cli::{Args, connect_cli, host_cli};
 pub use util::{lang, steam_helper};
 
-use app::AppSavedState;
 use audio_settings::AudioSettings;
 use bookkeeping::{mod_manager, releases};
 use game_map::ImageMap;
 use game_settings::{DefaultSettings, GameSettings};
 use lang::tr;
-use mod_manager::ModmanagerSettings;
 use player_cosmetics::player_path;
 use player_settings::{PlayerAppearance, PlayerColor, PlayerPicker};
-
-use serde::{Deserialize, Serialize};
 
 mod bookkeeping;
 mod lobby_code;
@@ -52,13 +48,4 @@ impl Drop for NetManStopOnDrop {
         self.0.continue_running.store(false, Ordering::Relaxed);
         self.1.take().unwrap().join().unwrap();
     }
-}
-
-#[derive(Debug, Serialize, Deserialize, Default)]
-#[serde(default)]
-pub struct Settings {
-    color: PlayerAppearance,
-    app: AppSavedState,
-    modmanager: ModmanagerSettings,
-    audio: AudioSettings,
 }

--- a/noita-proxy/src/main.rs
+++ b/noita-proxy/src/main.rs
@@ -36,7 +36,7 @@ async fn main() {
             log.clone()
                 .parent()
                 .unwrap()
-                .join(paths::DEFAULT_OLD_PROXY_LOG_NAME),
+                .join(paths::DEFAULT_PROXY_LOG_OLD_NAME),
         );
     }
     let file = File::create(log);

--- a/noita-proxy/src/main.rs
+++ b/noita-proxy/src/main.rs
@@ -4,7 +4,7 @@ use eframe::{
     NativeOptions,
     egui::{IconData, ViewportBuilder},
 };
-use noita_proxy::{App, Args, connect_cli, host_cli};
+use noita_proxy::{App, Args, connect_cli, host_cli, paths};
 use std::{
     backtrace, fs,
     fs::File,
@@ -26,14 +26,17 @@ async fn main() {
         }
     }
     let log = if let Ok(path) = std::env::current_exe() {
-        path.parent().unwrap().join("ew_log.txt")
+        path.parent().unwrap().join(paths::DEFAULT_PROXY_LOG_NAME)
     } else {
-        "ew_log.txt".into()
+        paths::DEFAULT_PROXY_LOG_NAME.into()
     };
     if log.exists() {
         let _ = fs::copy(
             log.clone(),
-            log.clone().parent().unwrap().join("ew_log_old.txt"),
+            log.clone()
+                .parent()
+                .unwrap()
+                .join(paths::DEFAULT_OLD_PROXY_LOG_NAME),
         );
     }
     let file = File::create(log);

--- a/noita-proxy/src/net.rs
+++ b/noita-proxy/src/net.rs
@@ -28,8 +28,9 @@ use std::{
 use world::WorldManager;
 
 use crate::lobby_code::LobbyKind;
-use crate::mod_manager::{ModmanagerSettings, get_mods};
+use crate::mod_manager::get_mods;
 use crate::net::world::world_model::ChunkData;
+use crate::paths::Paths;
 use crate::player_cosmetics::{PlayerPngDesc, create_player_png, get_player_skin};
 use crate::steam_helper::LobbyExtraData;
 use crate::{
@@ -186,9 +187,7 @@ pub struct NetManagerInit {
     pub my_nickname: String,
     pub save_state: SaveState,
     pub cosmetics: (bool, bool, bool),
-    pub mod_path: PathBuf,
-    pub player_path: PathBuf,
-    pub modmanager_settings: ModmanagerSettings,
+    pub paths: NetManagerPaths,
     pub player_png_desc: PlayerPngDesc,
     pub noita_port: u16,
 }
@@ -329,8 +328,8 @@ impl NetManager {
     pub fn new_desc(&self, desc: PlayerPngDesc, player_image: RgbaImage) {
         create_player_png(
             self.peer.my_id(),
-            &self.init_settings.mod_path,
-            &self.init_settings.player_path,
+            &self.init_settings.paths.noita_quantew_install,
+            &self.init_settings.paths.noita_quantew_player_spritesheet,
             &desc,
             self.is_host(),
             &mut self.players_sprite.lock().unwrap(),
@@ -422,7 +421,7 @@ impl NetManager {
             audio: audio_state,
         };
         let mut last_iter = Instant::now();
-        let path = crate::player_path(self.init_settings.modmanager_settings.mod_path());
+        let path = crate::player_path(self.init_settings.paths.noita_quantew_install.clone());
         let player_image = if path.exists() {
             image::open(path)
                 .unwrap_or(ImageRgba8(RgbaImage::new(20, 20)))
@@ -434,8 +433,8 @@ impl NetManager {
         // Create appearance files for local player.
         create_player_png(
             self.peer.my_id(),
-            &self.init_settings.mod_path,
-            &self.init_settings.player_path,
+            &self.init_settings.paths.noita_quantew_install,
+            &self.init_settings.paths.noita_quantew_player_spritesheet,
             &self.init_settings.player_png_desc,
             self.is_host(),
             &mut self.players_sprite.lock().unwrap(),
@@ -674,8 +673,8 @@ impl NetManager {
                     info!("Created temporary appearance for {id}");
                     create_player_png(
                         id,
-                        &self.init_settings.mod_path,
-                        &self.init_settings.player_path,
+                        &self.init_settings.paths.noita_quantew_install,
+                        &self.init_settings.paths.noita_quantew_player_spritesheet,
                         &PlayerPngDesc::default(),
                         id == self.peer.host_id(),
                         &mut self.players_sprite.lock().unwrap(),
@@ -780,7 +779,7 @@ impl NetManager {
                 let _ = sendm.send(colors);
             }
             NetMsg::RequestMods => {
-                if let Some(n) = &self.init_settings.modmanager_settings.game_save_path {
+                if let Some(n) = &self.init_settings.paths.noita_save {
                     let res = get_mods(n);
                     if let Ok(mods) = res {
                         self.send(src, &NetMsg::Mods { mods }, Reliability::Reliable)
@@ -822,8 +821,8 @@ impl NetManager {
                 // Create proper appearance files for new player.
                 create_player_png(
                     src,
-                    &self.init_settings.mod_path,
-                    &self.init_settings.player_path,
+                    &self.init_settings.paths.noita_quantew_install,
+                    &self.init_settings.paths.noita_quantew_player_spritesheet,
                     &rgb,
                     host,
                     &mut self.players_sprite.lock().unwrap(),
@@ -1467,11 +1466,9 @@ impl NetManager {
                 settings.seed = rand::random();
             }
             info!("New seed: {}", settings.seed);
-            settings.progress = self
-                .init_settings
-                .modmanager_settings
-                .get_progress()
-                .unwrap_or_default();
+            settings.progress =
+                crate::mod_manager::get_progress(self.init_settings.paths.noita_save.as_deref())
+                    .unwrap_or_default();
             if settings.world_num == u8::MAX {
                 settings.world_num = 0
             } else {

--- a/noita-proxy/src/net.rs
+++ b/noita-proxy/src/net.rs
@@ -161,6 +161,27 @@ fn get_flags(mut flags: String) -> Option<FlagType> {
     }
 }
 
+/// A safer subset of Paths for use with NetManager
+#[derive(Debug)]
+pub struct NetManagerPaths {
+    pub noita_quantew_install: PathBuf,
+    pub noita_quantew_player_spritesheet: PathBuf,
+    pub noita_save: Option<PathBuf>,
+}
+
+impl NetManagerPaths {
+    pub fn try_from_paths(paths: &Paths) -> Option<NetManagerPaths> {
+        let noita_quantew_install = paths.noita_quantew_install.as_ref()?;
+        let noita_quantew_player_spritesheet = paths.noita_quantew_player_spritesheet.as_ref()?;
+        let noita_save = paths.noita_save.as_ref();
+        Some(NetManagerPaths {
+            noita_quantew_install: noita_quantew_install.clone(),
+            noita_quantew_player_spritesheet: noita_quantew_player_spritesheet.clone(),
+            noita_save: noita_save.cloned(),
+        })
+    }
+}
+
 pub struct NetManagerInit {
     pub my_nickname: String,
     pub save_state: SaveState,

--- a/noita-proxy/src/paths.rs
+++ b/noita-proxy/src/paths.rs
@@ -1,0 +1,128 @@
+//! Paths that the proxy will uses
+
+use std::path::PathBuf;
+
+use directories::ProjectDirs;
+use serde::{Deserialize, Serialize};
+
+pub const DEFAULT_PROXY_LOG_NAME: &str = "ew_log.txt";
+pub const DEFAULT_OLD_PROXY_LOG_NAME: &str = "ew_log_old.txt";
+pub const DEFAULT_SETTINGS_NAME: &str = "proxy.ron";
+pub const DEFAULT_SAVE_STATE_NAME: &str = "save_state"; // this is a dir
+
+pub const STEAM_COMPATDATA_NOITA_SAVE: &str =
+    "compatdata/881100/pfx/drive_c/users/steamuser/AppData/LocalLow/Nolla_Games_Noita";
+
+pub const NOITA_QUANTEW_INSTALL: &str = "mods/quant.ew";
+pub const QUANTEW_PLAYER_SPRITESHEET: &str = "files/system/player/unmodified.png";
+
+pub const PROJECT_DIRS_ORGANIZATION: &str = "quant";
+pub const PROJECT_DIRS_APPLICATION: &str = "entangledworlds";
+
+#[derive(Debug, Serialize, Deserialize, Default, Clone)]
+#[serde(default)]
+pub struct Paths {
+    /// Usually
+    /// - Windows: [TODO]
+    /// - Linux: `/home/<name>/.local/share/Steam/steamapps/common/Noita`
+    ///
+    /// This is not serialized because it's currently always realized from [`Self::noita_exe`].
+    #[serde(skip)]
+    pub noita_install: Option<PathBuf>,
+
+    /// Usually
+    /// - Windows: [TODO]
+    /// - Linux: `/home/<name>/.local/share/Steam/steamapps/common/Noita/noita.exe`
+    pub noita_exe: Option<PathBuf>,
+
+    /// Usually
+    /// - Windows: [TODO]
+    /// - Linux: `/home/<name>/.local/share/Steam/steamapps/common/Noita/mods/quant.ew`
+    ///
+    /// This is not serialized because it's currently always realized from [`Self::noita_exe`].
+    #[serde(skip)]
+    pub noita_quantew_install: Option<PathBuf>,
+
+    /// Usually
+    /// - Windows: [TODO]
+    /// - Linux: `/home/<name>/.local/share/Steam/steamapps/common/Noita/mods/quant.ew/files/system/player/unmodified.png`
+    ///
+    /// This is not serialized because it's currently always realized from [`Self::noita_exe`].
+    #[serde(skip)]
+    pub noita_quantew_player_spritesheet: Option<PathBuf>,
+
+    /// Usually
+    /// - Windows: `C:\Users\<name>\AppData\LocalLow\Nolla_Games_Noita`
+    /// - Linux: `/home/<name>/.local/share/Steam/steamapps/compatdata/881100/pfx/drive_c/users/steamuser/AppData/LocalLow/Nolla_Games_Noita`
+    pub noita_save: Option<PathBuf>,
+
+    /// Usually
+    /// - Windows: [TODO]
+    /// - Linux: `/home/<name>/.config/entangledworlds/proxy.ron`
+    ///
+    /// This is not serialized because this path is always either taken from CLI args or searched.
+    #[serde(skip)]
+    pub proxy_settings: Option<PathBuf>,
+
+    /// Usually
+    /// - Windows: [TODO]
+    /// - Linux: `/home/<name>/.local/share/entangledworlds/save_state/`
+    ///
+    /// This is not serialized because this path is always either taken from CLI args or searched.
+    #[serde(skip)]
+    pub proxy_save_state: Option<PathBuf>,
+}
+
+#[rustfmt::skip]
+impl Paths {
+    pub fn noita_install(&self) -> &PathBuf {
+        self.noita_install.as_ref().expect("noita_install path is Some")
+    }
+    pub fn noita_exe(&self) -> &PathBuf {
+        self.noita_exe.as_ref().expect("noita_exe path is Some")
+    }
+    pub fn noita_quantew_install(&self) -> &PathBuf {
+        self.noita_quantew_install.as_ref().expect("noita_quantew_install path is Some")
+    }
+    pub fn noita_quantew_player_spritesheet(&self) -> &PathBuf {
+        self.noita_quantew_player_spritesheet.as_ref().expect("noita_quantew_player_spritesheet path is Some")
+    }
+    pub fn noita_save(&self) -> &PathBuf {
+        self.noita_save.as_ref().expect("noita_save path is Some")
+    }
+    pub fn proxy_settings(&self) -> &PathBuf {
+        self.proxy_settings.as_ref().expect("proxy_settings path is Some")
+    }
+    pub fn proxy_save_state(&self) -> &PathBuf {
+        self.proxy_save_state.as_ref().expect("save_state path is Some")
+    }
+}
+
+pub fn project_dirs() -> Option<ProjectDirs> {
+    ProjectDirs::from("", PROJECT_DIRS_ORGANIZATION, PROJECT_DIRS_APPLICATION)
+}
+
+pub fn proxy_exe_dir() -> PathBuf {
+    std::env::current_exe()
+        .map(|p| p.parent().unwrap().to_path_buf())
+        .unwrap_or(".".into())
+}
+
+/// Set `noita_install` from `noita_exe`
+/// Set `noita_quantew_install` from `noita_install`
+/// Set `noita_quantew_player_spritesheet` from `noita_quantew_install`
+pub fn realize_noita_paths_from_noita_exe(paths: &mut Paths) {
+    let noita_exe = paths.noita_exe();
+    paths.noita_install = Some(
+        noita_exe
+            .parent()
+            .expect("noita_exe is valid")
+            .to_path_buf(),
+    );
+    paths.noita_quantew_install = Some(paths.noita_install().join(NOITA_QUANTEW_INSTALL));
+    paths.noita_quantew_player_spritesheet = Some(
+        paths
+            .noita_quantew_install()
+            .join(QUANTEW_PLAYER_SPRITESHEET),
+    );
+}

--- a/noita-proxy/src/paths.rs
+++ b/noita-proxy/src/paths.rs
@@ -23,49 +23,49 @@ pub const PROJECT_DIRS_APPLICATION: &str = "entangledworlds";
 #[serde(default)]
 pub struct Paths {
     /// Usually
-    /// - Windows: [TODO]
-    /// - Linux: `/home/<name>/.local/share/Steam/steamapps/common/Noita`
+    /// - Windows: `C:\Program Files (x86)\Steam\steamapps\common\Noita`
+    /// - Linux: `$XDG_DATA_HOME/Steam/steamapps/common/Noita`
     ///
     /// This is not serialized because it's currently always realized from [`Self::noita_exe`].
     #[serde(skip)]
     pub noita_install: Option<PathBuf>,
 
     /// Usually
-    /// - Windows: [TODO]
-    /// - Linux: `/home/<name>/.local/share/Steam/steamapps/common/Noita/noita.exe`
+    /// - Windows: `C:\Program Files (x86)\Steam\steamapps\common\Noita\noita.exe`
+    /// - Linux: `$XDG_DATA_HOME/Steam/steamapps/common/Noita/noita.exe`
     pub noita_exe: Option<PathBuf>,
 
     /// Usually
-    /// - Windows: [TODO]
-    /// - Linux: `/home/<name>/.local/share/Steam/steamapps/common/Noita/mods/quant.ew`
+    /// - Windows: `C:\Program Files (x86)\Steam\steamapps\common\Noita\mods\quant.ew`
+    /// - Linux: `$XDG_DATA_HOME/Steam/steamapps/common/Noita/mods/quant.ew`
     ///
     /// This is not serialized because it's currently always realized from [`Self::noita_exe`].
     #[serde(skip)]
     pub noita_quantew_install: Option<PathBuf>,
 
     /// Usually
-    /// - Windows: [TODO]
-    /// - Linux: `/home/<name>/.local/share/Steam/steamapps/common/Noita/mods/quant.ew/files/system/player/unmodified.png`
+    /// - Windows: `C:\Program Files (x86)\Steam\steamapps\common\Noita\mods\quant.ew\files\system\player\unmodified.png`
+    /// - Linux: `$XDG_DATA_HOME/Steam/steamapps/common/Noita/mods/quant.ew/files/system/player/unmodified.png`
     ///
     /// This is not serialized because it's currently always realized from [`Self::noita_exe`].
     #[serde(skip)]
     pub noita_quantew_player_spritesheet: Option<PathBuf>,
 
     /// Usually
-    /// - Windows: `C:\Users\<name>\AppData\LocalLow\Nolla_Games_Noita`
-    /// - Linux: `/home/<name>/.local/share/Steam/steamapps/compatdata/881100/pfx/drive_c/users/steamuser/AppData/LocalLow/Nolla_Games_Noita`
+    /// - Windows: `%USERPROFILE%\AppData\LocalLow\Nolla_Games_Noita\`
+    /// - Linux: `$XDG_DATA_HOME/Steam/steamapps/compatdata/881100/pfx/drive_c/users/steamuser/AppData/LocalLow/Nolla_Games_Noita/`
     pub noita_save: Option<PathBuf>,
 
     /// Usually
-    /// - Windows: [TODO]
-    /// - Linux: `/home/<name>/.config/entangledworlds/proxy.ron`
+    /// - Windows: `%APPDATA%\quant\entangledworlds\proxy.ron`
+    /// - Linux: `$XDG_CONFIG_HOME/entangledworlds/proxy.ron`
     ///
     /// This is not serialized because this path is always either taken from CLI args or searched.
     #[serde(skip)]
     pub proxy_settings: Option<PathBuf>,
 
     /// Usually
-    /// - Windows: [TODO]
+    /// - Windows: `%APPDATA%\quant\entangledworlds\save_state\`
     /// - Linux: `/home/<name>/.local/share/entangledworlds/save_state/`
     ///
     /// This is not serialized because this path is always either taken from CLI args or searched.

--- a/noita-proxy/src/paths.rs
+++ b/noita-proxy/src/paths.rs
@@ -66,7 +66,7 @@ pub struct Paths {
 
     /// Usually
     /// - Windows: `%APPDATA%\quant\entangledworlds\save_state\`
-    /// - Linux: `/home/<name>/.local/share/entangledworlds/save_state/`
+    /// - Linux: `$XDG_DATA_HOME/entangledworlds/save_state/`
     ///
     /// This is not serialized because this path is always either taken from CLI args or searched.
     #[serde(skip)]

--- a/noita-proxy/src/paths.rs
+++ b/noita-proxy/src/paths.rs
@@ -6,9 +6,9 @@ use directories::ProjectDirs;
 use serde::{Deserialize, Serialize};
 
 pub const DEFAULT_PROXY_LOG_NAME: &str = "ew_log.txt";
-pub const DEFAULT_OLD_PROXY_LOG_NAME: &str = "ew_log_old.txt";
-pub const DEFAULT_SETTINGS_NAME: &str = "proxy.ron";
-pub const DEFAULT_SAVE_STATE_NAME: &str = "save_state"; // this is a dir
+pub const DEFAULT_PROXY_LOG_OLD_NAME: &str = "ew_log_old.txt";
+pub const DEFAULT_PROXY_SETTINGS_NAME: &str = "proxy.ron";
+pub const DEFAULT_PROXY_SAVE_STATE_NAME: &str = "save_state"; // this is a dir
 
 pub const STEAM_COMPATDATA_NOITA_SAVE: &str =
     "compatdata/881100/pfx/drive_c/users/steamuser/AppData/LocalLow/Nolla_Games_Noita";


### PR DESCRIPTION
All paths that proxy requires and handles is unify into the module `paths` with proper documentations and more self descriptive names. Struct such as `SavePaths` is remained and a new struct `NetManagerPaths` (to replace `ModmanagerSettings`) is used as a safer subset of `Paths`. Many other part of the code base is updated to use the new module excepts `noita_launcher` for the time being. It should be updated with a future PR.

This rewrite also raises previously undocumented issues due to some oversight.
- Launching the proxy headless for the first time (no proxy.ron) will crash due to missing path to `noita.exe`. It is changed to a panic with a proper message at the momment. Though, it seems this path is only required for the `net` module which all it is used for is `create_player_png`.
- Launching the GUI for the first time (no proxy.ron) will causes some part of the player model to be missing. This is due to the path to player sprite is being initialize before the app finding the path to `noita.exe` and thus the path to player sprite is only able to get the path from the cache which resides in proxy.ron. This should be fixed with a future PR.
- An unreachable code macro is reached if you pass an invalid path for `noita.exe` to `--exe-path` running in GUI due to missing else clause. It is currently fixed with a panic with a proper error message.

`Settings` is changed to use the new `Paths` for saving paths instead of `SavePaths`. This would likely break old config. Would you prefer if it is remain as `SavePaths` instead? (In the future, I'd probably like to save the rest of the paths in the struct so one can have full control over what path the proxy is using)