### PR TITLE
Fix AudioSettings::disabled still trying to interact with audio library

### DIFF
--- a/noita-proxy/src/audio_settings.rs
+++ b/noita-proxy/src/audio_settings.rs
@@ -103,7 +103,7 @@ impl AudioSettings {
         changed |= ui.checkbox(&mut self.mute_out, "mute output").changed();
         if main {
             changed |= ui.checkbox(&mut self.disabled, "disabled").changed();
-            if self.input_devices.is_empty() {
+            if self.input_devices.is_empty() && !self.disabled {
                 #[cfg(target_os = "linux")]
                 let host = cpal::available_hosts()
                     .into_iter()

--- a/noita-proxy/src/net.rs
+++ b/noita-proxy/src/net.rs
@@ -85,7 +85,7 @@ pub(crate) struct NetInnerState {
     pub(crate) ms: Option<MessageSocket<NoitaOutbound, NoitaInbound>>,
     world: WorldManager,
     des: DesManager,
-    audio: AudioManager,
+    audio: Option<AudioManager>,
     explosion_data: Vec<ExplosionData>,
     had_a_disconnect: bool,
     flags: FxHashSet<String>,
@@ -404,7 +404,11 @@ impl NetManager {
         info!("Is host: {is_host}");
 
         let audio_settings = self.audio.lock().unwrap().clone();
-        let audio_state = AudioManager::new(audio_settings);
+        let audio_state = if !audio_settings.disabled {
+            Some(AudioManager::new(audio_settings))
+        } else {
+            None
+        };
 
         let (world, rx, recv, sendm, tx) = WorldManager::new(
             is_host,
@@ -577,7 +581,11 @@ impl NetManager {
             }
 
             let mut audio_data = Vec::new();
-            while let Ok(data) = state.audio.recv_audio() {
+            while let Some(data) = state
+                .audio
+                .as_mut()
+                .and_then(|audio| audio.recv_audio().ok())
+            {
                 audio_data.push(data)
             }
             if !audio_data.is_empty() {
@@ -743,6 +751,9 @@ impl NetManager {
                 state.try_ms_write(&NoitaInbound::ProxyToWorldSync(msg));
             }
             NetMsg::AudioData(data, global, tx, ty, vol) => {
+                if state.audio.is_none() {
+                    return;
+                }
                 if !self.is_cess.load(Ordering::Relaxed) {
                     let audio = self.audio.lock().unwrap().clone();
                     let pos = if audio.player_position {
@@ -758,6 +769,8 @@ impl NetManager {
                     };
                     state
                         .audio
+                        .as_mut()
+                        .expect("AudioSettings is checked to be some")
                         .play_audio(audio, pos, src, data, global, (tx, ty), vol);
                 }
             }

--- a/noita-proxy/src/net.rs
+++ b/noita-proxy/src/net.rs
@@ -751,28 +751,25 @@ impl NetManager {
                 state.try_ms_write(&NoitaInbound::ProxyToWorldSync(msg));
             }
             NetMsg::AudioData(data, global, tx, ty, vol) => {
-                if state.audio.is_none() {
+                let Some(state_audio) = &mut state.audio else {
+                    return;
+                };
+                if self.is_cess.load(Ordering::Relaxed) {
                     return;
                 }
-                if !self.is_cess.load(Ordering::Relaxed) {
-                    let audio = self.audio.lock().unwrap().clone();
-                    let pos = if audio.player_position {
-                        (
-                            self.player_pos.0.load(Ordering::Relaxed),
-                            self.player_pos.1.load(Ordering::Relaxed),
-                        )
-                    } else {
-                        (
-                            self.camera_pos.0.load(Ordering::Relaxed),
-                            self.camera_pos.1.load(Ordering::Relaxed),
-                        )
-                    };
-                    state
-                        .audio
-                        .as_mut()
-                        .expect("AudioSettings is checked to be some")
-                        .play_audio(audio, pos, src, data, global, (tx, ty), vol);
-                }
+                let audio = self.audio.lock().unwrap().clone();
+                let pos = if audio.player_position {
+                    (
+                        self.player_pos.0.load(Ordering::Relaxed),
+                        self.player_pos.1.load(Ordering::Relaxed),
+                    )
+                } else {
+                    (
+                        self.camera_pos.0.load(Ordering::Relaxed),
+                        self.camera_pos.1.load(Ordering::Relaxed),
+                    )
+                };
+                state_audio.play_audio(audio, pos, src, data, global, (tx, ty), vol);
             }
             NetMsg::PlayerPosition(x, y, is_dead, does_exist) => {
                 let map = &mut self.players_sprite.lock().unwrap();


### PR DESCRIPTION
Make NetInnerState::audio optional. When AudioSettings::disabled is true, make no attempt to interact with any audio library to prevent further issues. This still doesn't fix the underlying bug of audio being wonky on Linux but it being disabled should keep audio functioning.