### PR TITLE
fix(sync): prevent stale component/entity crashes and add revive_on_drop option

### DIFF
--- a/ewext/src/modules/entity_sync/diff_model.rs
+++ b/ewext/src/modules/entity_sync/diff_model.rs
@@ -420,10 +420,11 @@ impl LocalDiffModelTracker {
             }
         }
 
-        if let Some(damage) =
-            entity_manager.try_get_first_component::<DamageModelComponent>(ComponentTag::None)
+        if entity.is_alive()
+            && let Some(damage) =
+                entity_manager.try_get_first_component::<DamageModelComponent>(ComponentTag::None)
+            && let Ok(hp) = damage.hp()
         {
-            let hp = damage.hp()?;
             info.hp = hp as f32;
         }
 
@@ -1076,16 +1077,21 @@ impl LocalDiffModel {
             mom(entity_manager, entity_data.counter, None)?;
             sun(entity_manager, entity_data.counter)?;
             if entity_data.hp != -1.0
+                && entity.is_alive()
                 && let Some(damage) = entity_manager
                     .try_get_first_component::<DamageModelComponent>(ComponentTag::None)
             {
-                if entity_data.hp > damage.max_hp_cap()? as f32 {
-                    damage.set_max_hp_cap(entity_data.hp as f64)?;
+                if let Ok(cap) = damage.max_hp_cap()
+                    && entity_data.hp > cap as f32
+                {
+                    let _ = damage.set_max_hp_cap(entity_data.hp as f64);
                 }
-                if entity_data.hp > damage.max_hp()? as f32 {
-                    damage.set_max_hp(entity_data.hp as f64)?;
+                if let Ok(max) = damage.max_hp()
+                    && entity_data.hp > max as f32
+                {
+                    let _ = damage.set_max_hp(entity_data.hp as f64);
                 }
-                damage.set_hp(entity_data.hp as f64)?;
+                let _ = damage.set_hp(entity_data.hp as f64);
             }
             if !entity_data.drops_gold {
                 let n = entity_manager
@@ -1781,46 +1787,54 @@ impl RemoteDiffModel {
                 vel.set_m_velocity((vx, vy))?;
             }
         }
-        if let Some(damage) =
-            entity_manager.try_get_first_component::<DamageModelComponent>(ComponentTag::None)
+        if entity.is_alive()
+            && let Some(damage) =
+                entity_manager.try_get_first_component::<DamageModelComponent>(ComponentTag::None)
         {
-            if entity_info.hp > damage.max_hp()? as f32 {
-                damage.set_max_hp(entity_info.hp as f64)?
+            if let Ok(max_hp) = damage.max_hp()
+                && entity_info.hp > max_hp as f32
+            {
+                let _ = damage.set_max_hp(entity_info.hp as f64);
             }
-            let current_hp = damage.hp()? as f32;
-            if current_hp > entity_info.hp {
-                let old = damage.object_get_value::<f64>("damage_multipliers", "curse")?;
-                if old != 1.0 {
-                    damage.object_set_value("damage_multipliers", "curse", 1.0)?
+            if let Ok(current_hp) = damage.hp().map(|h| h as f32) {
+                if current_hp > entity_info.hp {
+                    let old = damage
+                        .object_get_value::<f64>("damage_multipliers", "curse")
+                        .unwrap_or(1.0);
+                    if old != 1.0 {
+                        let _ = damage.object_set_value("damage_multipliers", "curse", 1.0);
+                    }
+                    let _ = entity.inflict_damage(
+                        (current_hp - entity_info.hp) as f64,
+                        DamageType::DamageCurse,
+                        "hp sync",
+                        None,
+                    );
+                    if old != 0.0 {
+                        let _ = damage.object_set_value("damage_multipliers", "curse", old);
+                    }
+                    let _ = damage.set_hp(entity_info.hp as f64);
+                } else if current_hp < entity_info.hp {
+                    if current_hp < 0.0 && entity_info.hp >= 0.0 {
+                        let _ = damage.set_hp(f32::MIN_POSITIVE as f64);
+                    }
+                    let old = damage
+                        .object_get_value::<f64>("damage_multipliers", "healing")
+                        .unwrap_or(1.0);
+                    if old != 0.0 {
+                        let _ = damage.object_set_value("damage_multipliers", "healing", 1.0);
+                    }
+                    let _ = entity.inflict_damage(
+                        (current_hp - entity_info.hp) as f64,
+                        DamageType::DamageHealing,
+                        "hp sync",
+                        None,
+                    );
+                    if old != 1.0 {
+                        let _ = damage.object_set_value("damage_multipliers", "healing", old);
+                    }
+                    let _ = damage.set_hp(entity_info.hp as f64);
                 }
-                entity.inflict_damage(
-                    (current_hp - entity_info.hp) as f64,
-                    DamageType::DamageCurse,
-                    "hp sync",
-                    None,
-                )?;
-                if old != 0.0 {
-                    damage.object_set_value("damage_multipliers", "curse", old)?
-                }
-                damage.set_hp(entity_info.hp as f64)?;
-            } else if current_hp < entity_info.hp {
-                if current_hp < 0.0 && entity_info.hp >= 0.0 {
-                    damage.set_hp(f32::MIN_POSITIVE as f64)?;
-                }
-                let old = damage.object_get_value::<f64>("damage_multipliers", "healing")?;
-                if old != 0.0 {
-                    damage.object_set_value("damage_multipliers", "healing", 1.0)?
-                }
-                entity.inflict_damage(
-                    (current_hp - entity_info.hp) as f64,
-                    DamageType::DamageHealing,
-                    "hp sync",
-                    None,
-                )?;
-                if old != 0.0 {
-                    damage.object_set_value("damage_multipliers", "healing", old)?
-                }
-                damage.set_hp(entity_info.hp as f64)?;
             }
         }
 
@@ -2098,8 +2112,9 @@ impl RemoteDiffModel {
             {
                 inv.children(None).for_each(|e| e.kill())
             }
-            if let Some(damage) =
-                entity_manager.try_get_first_component::<DamageModelComponent>(ComponentTag::None)
+            if entity.is_alive()
+                && let Some(damage) = entity_manager
+                    .try_get_first_component::<DamageModelComponent>(ComponentTag::None)
             {
                 entity_manager.remove_ent(&entity);
                 entity
@@ -2107,24 +2122,28 @@ impl RemoteDiffModel {
                     .for_each(|ent| ent.kill());
                 self.pending_remove.retain(|l| l != &lid);
                 if !wait_on_kill {
-                    damage.set_wait_for_kill_flag_on_death(false)?;
+                    let _ = damage.set_wait_for_kill_flag_on_death(false);
                 }
-                damage.object_set_value("damage_multipliers", "curse", 1.0)?;
-                entity.inflict_damage(
-                    damage.hp()? + f32::MIN_POSITIVE as f64,
-                    DamageType::DamageCurse,
-                    "kill sync",
-                    responsible_entity,
-                )?;
-                damage.set_ui_report_damage(false)?;
-                entity.inflict_damage(
-                    damage.max_hp()? * 100.0,
-                    DamageType::DamageCurse,
-                    "kill sync",
-                    responsible_entity,
-                )?;
+                let _ = damage.object_set_value("damage_multipliers", "curse", 1.0);
+                if let Ok(hp) = damage.hp() {
+                    let _ = entity.inflict_damage(
+                        hp + f32::MIN_POSITIVE as f64,
+                        DamageType::DamageCurse,
+                        "kill sync",
+                        responsible_entity,
+                    );
+                }
+                let _ = damage.set_ui_report_damage(false);
+                if let Ok(max) = damage.max_hp() {
+                    let _ = entity.inflict_damage(
+                        max * 100.0,
+                        DamageType::DamageCurse,
+                        "kill sync",
+                        responsible_entity,
+                    );
+                }
                 if wait_on_kill {
-                    damage.set_kill_now(true)?;
+                    let _ = damage.set_kill_now(true);
                 } else {
                     entity.kill()
                 }

--- a/noita_api/src/lib.rs
+++ b/noita_api/src/lib.rs
@@ -1453,41 +1453,31 @@ impl EntityManager {
         Ok(true)
     }
     pub fn try_get_first_component<C: Component>(&self, tag: ComponentTag) -> Option<C> {
-        if self.use_cache {
-            return self
-                .entity()
-                .try_get_first_component::<C>(if matches!(tag, ComponentTag::None) {
-                    None
-                } else {
-                    Some(tag.to_str().into())
-                })
-                .unwrap_or(None);
+        if !self.entity().is_alive() {
+            return None;
         }
-        self.current_data.components[const { CachedComponent::from_component::<C>() as usize }]
-            .iter()
-            .find(|c| c.enabled && (tag == ComponentTag::None || c.tags.get(tag as u16)))
-            .map(|com| C::from(com.id))
+        self.entity()
+            .try_get_first_component::<C>(if matches!(tag, ComponentTag::None) {
+                None
+            } else {
+                Some(tag.to_str().into())
+            })
+            .unwrap_or(None)
     }
     pub fn try_get_first_component_including_disabled<C: Component>(
         &self,
         tag: ComponentTag,
     ) -> Option<C> {
-        if self.use_cache {
-            return self
-                .entity()
-                .try_get_first_component_including_disabled::<C>(
-                    if matches!(tag, ComponentTag::None) {
-                        None
-                    } else {
-                        Some(tag.to_str().into())
-                    },
-                )
-                .unwrap_or(None);
+        if !self.entity().is_alive() {
+            return None;
         }
-        self.current_data.components[const { CachedComponent::from_component::<C>() as usize }]
-            .iter()
-            .find(|c| tag == ComponentTag::None || c.tags.get(tag as u16))
-            .map(|c| C::from(c.id))
+        self.entity()
+            .try_get_first_component_including_disabled::<C>(if matches!(tag, ComponentTag::None) {
+                None
+            } else {
+                Some(tag.to_str().into())
+            })
+            .unwrap_or(None)
     }
     pub fn get_first_component<C: Component>(&self, tag: ComponentTag) -> eyre::Result<C> {
         if self.use_cache {

--- a/noita_proxy/src/game_settings.rs
+++ b/noita_proxy/src/game_settings.rs
@@ -45,6 +45,7 @@ pub struct GameSettings {
     pub wait_for_time: Option<bool>,
     pub timed: Option<bool>,
     pub local_health_alternate_dont_run: Option<bool>,
+    pub revive_on_drop: Option<bool>,
 }
 
 pub struct DefaultSettings {
@@ -79,6 +80,7 @@ pub struct DefaultSettings {
     pub wait_for_time: bool,
     pub timed: bool,
     pub local_health_alternate_dont_run: bool,
+    pub revive_on_drop: bool,
 }
 
 impl Default for DefaultSettings {
@@ -115,6 +117,7 @@ impl Default for DefaultSettings {
             wait_for_time: false,
             timed: true,
             local_health_alternate_dont_run: false,
+            revive_on_drop: false,
         }
     }
 }
@@ -296,6 +299,13 @@ impl GameSettings {
                                         game_settings.local_health_alternate_dont_run = Some(temp)
                                     }
                                 }
+                                 {
+                                     let mut temp =
+                                         game_settings.revive_on_drop.unwrap_or(def.revive_on_drop);
+                                     if ui.checkbox(&mut temp, "Revive player anywhere when dropping heart").changed() {
+                                         game_settings.revive_on_drop = Some(temp)
+                                     }
+                                 }
                             }
                             LocalHealthMode::PermaDeath => {
                                 ui.label(tr("local_health_desc_1"));

--- a/noita_proxy/src/net.rs
+++ b/noita_proxy/src/net.rs
@@ -1060,6 +1060,10 @@ impl NetManager {
                             .local_health_alternate_dont_run
                             .unwrap_or(def.local_health_alternate_dont_run),
                     );
+                    state.try_ws_write_option(
+                        "revive_on_drop",
+                        settings.revive_on_drop.unwrap_or(def.revive_on_drop),
+                    );
                 }
                 LocalHealthMode::PvP => {
                     state.try_ws_write_option("pvp", true);

--- a/quant.ew/files/core/inventory_helper.lua
+++ b/quant.ew/files/core/inventory_helper.lua
@@ -206,6 +206,9 @@ function inventory_helper.get_item_data(player_data, fresh)
 end
 
 local function pickup_item(entity, item)
+    if not entity or not EntityGetIsAlive(entity) or not item or not EntityGetIsAlive(item) then
+        return
+    end
     local item_component = EntityGetFirstComponentIncludingDisabled(item, "ItemComponent")
     if item_component then
         ComponentSetValue2(item_component, "has_been_picked_by_player", true)

--- a/quant.ew/files/core/player_fns.lua
+++ b/quant.ew/files/core/player_fns.lua
@@ -606,16 +606,21 @@ function player_fns.get_active_held_item(player_entity)
 end
 
 function player_fns.get_current_slot(player_data)
+    if not player_data or not player_data.entity or not EntityGetIsAlive(player_data.entity) then
+        return
+    end
     local held_item = player_fns.get_active_held_item(player_data.entity)
-    if held_item ~= nil and held_item ~= 0 then
+    if held_item ~= nil and held_item ~= 0 and EntityGetIsAlive(held_item) then
         local item_comp = EntityGetFirstComponentIncludingDisabled(held_item, "ItemComponent")
 
-        -- the hell??
         if item_comp == nil then
             return
         end
 
         local slot_x, slot_y = ComponentGetValue2(item_comp, "inventory_slot")
+        if slot_x == nil or slot_y == nil then
+            return
+        end
         local ability_comp = EntityGetFirstComponentIncludingDisabled(held_item, "AbilityComponent")
 
         local is_wand = false
@@ -627,34 +632,37 @@ function player_fns.get_current_slot(player_data)
 end
 
 function player_fns.set_current_slot(slot_data, player_data)
+    if not slot_data or not player_data or not player_data.entity or not EntityGetIsAlive(player_data.entity) then
+        return
+    end
     local is_wand, slot_x, slot_y = slot_data[1], slot_data[2], slot_data[3]
-    if player_data.entity and EntityGetIsAlive(player_data.entity) then
-        local items = GameGetAllInventoryItems(player_data.entity) or {}
-        for i, item in ipairs(items) do
-            -- check id
+    local items = GameGetAllInventoryItems(player_data.entity) or {}
+    for i, item in ipairs(items) do
+        if EntityGetIsAlive(item) then
             local itemComp = EntityGetFirstComponentIncludingDisabled(item, "ItemComponent")
             if itemComp ~= nil then
                 local item_slot_x, item_slot_y = ComponentGetValue2(itemComp, "inventory_slot")
+                if item_slot_x ~= nil and item_slot_y ~= nil then
+                    local ability_comp = EntityGetFirstComponentIncludingDisabled(item, "AbilityComponent")
 
-                local ability_comp = EntityGetFirstComponentIncludingDisabled(item, "AbilityComponent")
-
-                local item_is_wand = false
-                if ability_comp and ComponentGetValue2(ability_comp, "use_gun_script") then
-                    item_is_wand = true
-                end
-
-                if item_slot_x == slot_x and item_slot_y == slot_y and item_is_wand == is_wand then
-                    local inventory2Comp =
-                        EntityGetFirstComponentIncludingDisabled(player_data.entity, "Inventory2Component")
-                    local mActiveItem = ComponentGetValue2(inventory2Comp, "mActiveItem")
-
-                    if mActiveItem ~= item then
-                        np.SetActiveHeldEntity(player_data.entity, item, false, false)
+                    local item_is_wand = false
+                    if ability_comp and ComponentGetValue2(ability_comp, "use_gun_script") then
+                        item_is_wand = true
                     end
-                    return true
+
+                    if item_slot_x == slot_x and item_slot_y == slot_y and item_is_wand == is_wand then
+                        local inventory2Comp =
+                            EntityGetFirstComponentIncludingDisabled(player_data.entity, "Inventory2Component")
+                        if inventory2Comp ~= nil then
+                            local mActiveItem = ComponentGetValue2(inventory2Comp, "mActiveItem")
+
+                            if mActiveItem ~= item then
+                                np.SetActiveHeldEntity(player_data.entity, item, false, false)
+                            end
+                            return true
+                        end
+                    end
                 end
-            else
-                print("something in inventory that is not an item")
             end
         end
     end

--- a/quant.ew/files/system/heart_statue/heart_statue.lua
+++ b/quant.ew/files/system/heart_statue/heart_statue.lua
@@ -4,6 +4,9 @@ local heart_statue = {}
 
 -- Manually remove item from the inventory
 local function enable_in_world(item)
+    if not item or not EntityGetIsAlive(item) then
+        return
+    end
     EntitySetComponentsWithTagEnabled(item, "enabled_in_hand", false)
     EntitySetComponentsWithTagEnabled(item, "enabled_in_inventory", false)
     EntitySetComponentsWithTagEnabled(item, "enabled_in_world", true)
@@ -13,6 +16,9 @@ local function enable_in_world(item)
 end
 
 local function find_player_cape(entity)
+    if not entity or not EntityGetIsAlive(entity) then
+        return nil
+    end
     local cape
     local player_child_entities = EntityGetAllChildren(entity)
     if player_child_entities ~= nil then
@@ -31,7 +37,11 @@ end
 rpc.opts_everywhere()
 rpc.opts_reliable()
 function rpc.add_player_cape_for_fun(peer_id)
-    local entity = ctx.players[peer_id].entity
+    local player_data = ctx.players[peer_id]
+    if not player_data or not player_data.entity or not EntityGetIsAlive(player_data.entity) then
+        return
+    end
+    local entity = player_data.entity
     local cape = find_player_cape(entity)
 
     if cape then
@@ -42,13 +52,19 @@ function rpc.add_player_cape_for_fun(peer_id)
     local player_cape_sprite_file = "mods/quant.ew/files/system/player/tmp/" .. peer_id .. "_cape.xml"
     local x, y = EntityGetTransform(entity)
     local cape2 = EntityLoad(player_cape_sprite_file, x, y)
-    EntityAddChild(entity, cape2)
+    if cape2 and EntityGetIsAlive(cape2) then
+        EntityAddChild(entity, cape2)
+    end
 end
 
 rpc.opts_everywhere()
 rpc.opts_reliable()
 function rpc.remove_cape(peer_id)
-    local entity = ctx.players[peer_id].entity
+    local player_data = ctx.players[peer_id]
+    if not player_data or not player_data.entity or not EntityGetIsAlive(player_data.entity) then
+        return
+    end
+    local entity = player_data.entity
     local cape = find_player_cape(entity)
 
     if cape then
@@ -58,6 +74,9 @@ function rpc.remove_cape(peer_id)
 end
 
 local function remove_legs(entity)
+    if not entity or not EntityGetIsAlive(entity) then
+        return
+    end
     local child_entities = EntityGetAllChildren(entity)
     if child_entities ~= nil then
         for _, child_entity in ipairs(child_entities) do
@@ -82,9 +101,9 @@ function rpc.remove_legs(peer_id)
         return
     end
 
-    local entity = ctx.players[peer_id].entity
-    if entity then
-        remove_legs(entity)
+    local player_data = ctx.players[peer_id]
+    if player_data and player_data.entity and EntityGetIsAlive(player_data.entity) then
+        remove_legs(player_data.entity)
     end
 end
 
@@ -97,6 +116,9 @@ local function add_legs(entity)
 
     async(function()
         wait(1)
+        if not entity or not EntityGetIsAlive(entity) then
+            return
+        end
         local x, y = EntityGetTransform(entity)
         for i = 1, 5 do
             local leg = EntityLoad("mods/quant.ew/files/system/heart_statue/heart_statue_leg.xml", x, y)
@@ -123,7 +145,11 @@ end
 rpc.opts_everywhere()
 rpc.opts_reliable()
 function rpc.got_thrown(peer_id, phys_transform)
-    local item = ctx.players[peer_id].entity
+    local player_data = ctx.players[peer_id]
+    if not player_data or not player_data.entity or not EntityGetIsAlive(player_data.entity) then
+        return
+    end
+    local item = player_data.entity
     enable_in_world(item)
 
     local child_entities = EntityGetAllChildren(item)
@@ -137,16 +163,21 @@ function rpc.got_thrown(peer_id, phys_transform)
         end
     end
 
-    local owner_peer_id = player_fns.get_player_data_by_local_entity_id(item).peer_id
-    if owner_peer_id == ctx.my_player.peer_id then
-        rpc.disable_running(ctx.my_player.peer_id)
-        ctx.my_player.heart_statue_running_data.running_start_frame = GameGetFrameNum() + 180
+    local owner_data = player_fns.get_player_data_by_local_entity_id(item)
+    if owner_data then
+        local owner_peer_id = owner_data.peer_id
+        if owner_peer_id == ctx.my_player.peer_id then
+            rpc.disable_running(ctx.my_player.peer_id)
+            ctx.my_player.heart_statue_running_data.running_start_frame = GameGetFrameNum() + 180
+        end
     end
 
-    if peer_id == ctx.my_player.peer_id then
+    if peer_id == ctx.my_player.peer_id and ctx.my_player and ctx.my_player.entity and EntityGetIsAlive(ctx.my_player.entity) then
         local phys_component = EntityGetFirstComponentIncludingDisabled(ctx.my_player.entity, "PhysicsBodyComponent")
         local t = phys_transform
-        np.PhysBodySetTransform(phys_component, t.px, t.py, t.pr, t.pvx, t.pvy, t.pvr)
+        if phys_component and t and t.px and t.py and t.pr and t.pvx and t.pvy and t.pvr then
+            np.PhysBodySetTransform(phys_component, t.px, t.py, t.pr, t.pvx, t.pvy, t.pvr)
+        end
     end
 end
 

--- a/quant.ew/files/system/local_health/local_health.lua
+++ b/quant.ew/files/system/local_health/local_health.lua
@@ -347,6 +347,7 @@ local function no_notplayer()
     else
         entity_name = "mods/quant.ew/files/system/heart_statue/heart_statue_running.xml"
     end
+    GameRemoveFlagRun("ew_flag_heart_picked_up")
     local ent = fake_polymorph_into_entity(entity_name)
     polymorph.switch_entity(ent)
 end
@@ -573,27 +574,46 @@ function module.on_world_update()
         rpc.send_status(status)
     end
 
+    local in_inventory = is_entity_in_quick_inventory(player_ent)
+    if in_inventory then
+        GameAddFlagRun("ew_flag_heart_picked_up")
+    end
+
     local heart_statue_should_revive =
         ctx.proxy_opt.no_notplayer
         and notplayer_active
-        and not is_entity_in_quick_inventory(player_ent)
+        and GameHasFlagRun("ew_flag_heart_picked_up")
+        and not in_inventory
 
     if heart_statue_should_revive then
-        local x, y = EntityGetTransform(ctx.my_player.entity)
-        for _, ent in ipairs(EntityGetInRadiusWithTag(x, y, 14, "drillable")) do
-            ent_filename = EntityGetFilename(ent)
-            if ent_filename == "data/entities/items/pickup/heart_fullhp.xml"
-                or ent_filename == "data/entities/items/pickup/heart_fullhp_temple.xml"
-            then
-                GameRemoveFlagRun("ew_flag_notplayer_active")
-                EntityKill(ent)
-                local ent = fake_unpolymorph()
-                remove_stuff(ent)
-                polymorph.switch_entity(ent)
-                spectate.disable_throwing(false, ctx.my_player.entity)
-                reduce_hp()
-                first = false
-                break
+        local revive_anywhere = ctx.proxy_opt.revive_on_drop or (ModSettingGet("quant.ew.revive_on_drop") == true)
+        if revive_anywhere then
+            GameRemoveFlagRun("ew_flag_notplayer_active")
+            GameRemoveFlagRun("ew_flag_heart_picked_up")
+            local ent_rev = fake_unpolymorph()
+            remove_stuff(ent_rev)
+            polymorph.switch_entity(ent_rev)
+            spectate.disable_throwing(false, ctx.my_player.entity)
+            reduce_hp()
+            first = false
+        else
+            local x, y = EntityGetTransform(ctx.my_player.entity)
+            for _, ent in ipairs(EntityGetInRadiusWithTag(x, y, 14, "drillable")) do
+                local ent_filename = EntityGetFilename(ent)
+                if ent_filename == "data/entities/items/pickup/heart_fullhp.xml"
+                    or ent_filename == "data/entities/items/pickup/heart_fullhp_temple.xml"
+                then
+                    GameRemoveFlagRun("ew_flag_notplayer_active")
+                    GameRemoveFlagRun("ew_flag_heart_picked_up")
+                    EntityKill(ent)
+                    local ent_rev = fake_unpolymorph()
+                    remove_stuff(ent_rev)
+                    polymorph.switch_entity(ent_rev)
+                    spectate.disable_throwing(false, ctx.my_player.entity)
+                    reduce_hp()
+                    first = false
+                    break
+                end
             end
         end
     end

--- a/quant.ew/files/system/player_sync.lua
+++ b/quant.ew/files/system/player_sync.lua
@@ -22,25 +22,32 @@ local function undc(ent)
 end
 
 function rpc.send_money_and_ingestion(money, delta, ingestion_size)
-    local entity = ctx.rpc_player_data.entity
+    local entity = ctx.rpc_player_data and ctx.rpc_player_data.entity
+    if not entity or not EntityGetIsAlive(entity) then
+        return
+    end
     local wallet = EntityGetFirstComponentIncludingDisabled(entity, "WalletComponent")
     if wallet ~= nil and money ~= nil then
         if ctx.proxy_opt.share_gold and last_money ~= nil then
-            local my_wallet = EntityGetFirstComponentIncludingDisabled(ctx.my_player.entity, "WalletComponent")
-            if my_wallet == nil then
-                my_wallet = EntityAddComponent2(ctx.my_player.entity, "WalletComponent", { money = last_money })
-            end
-            local cm = ComponentGetValue2(my_wallet, "money")
-            if cm ~= nil then
-                if ctx.is_host then
-                    ComponentSetValue2(my_wallet, "money", cm + delta)
-                elseif ctx.rpc_peer_id == ctx.host_id then
-                    local my_delta = 0
-                    if cm ~= last_money then
-                        my_delta = cm - last_money
+            if ctx.my_player and ctx.my_player.entity and EntityGetIsAlive(ctx.my_player.entity) then
+                local my_wallet = EntityGetFirstComponentIncludingDisabled(ctx.my_player.entity, "WalletComponent")
+                if my_wallet == nil then
+                    my_wallet = EntityAddComponent2(ctx.my_player.entity, "WalletComponent", { money = last_money })
+                end
+                if my_wallet ~= nil then
+                    local cm = ComponentGetValue2(my_wallet, "money")
+                    if cm ~= nil then
+                        if ctx.is_host then
+                            ComponentSetValue2(my_wallet, "money", cm + delta)
+                        elseif ctx.rpc_peer_id == ctx.host_id then
+                            local my_delta = 0
+                            if cm ~= last_money then
+                                my_delta = cm - last_money
+                            end
+                            last_money = money
+                            ComponentSetValue2(my_wallet, "money", money + my_delta)
+                        end
                     end
-                    last_money = money
-                    ComponentSetValue2(my_wallet, "money", money + my_delta)
                 end
             end
         end

--- a/quant.ew/settings.lua
+++ b/quant.ew/settings.lua
@@ -267,9 +267,14 @@ local function build_settings()
         },
         {
             category_id = "misc",
-            ui_name = "misc",
-            ui_description = "misc",
             settings = {
+                {
+                    id = "revive_on_drop",
+                    ui_name = "revive heart statue on drop",
+                    ui_description = "respawn dead player anywhere when their heart statue is dropped or thrown",
+                    value_default = false,
+                    scope = MOD_SETTING_SCOPE_RUNTIME,
+                },
                 {
                     id = "flex",
                     ui_name = "flexible updates",


### PR DESCRIPTION
## Summary of Changes

### 1. Fix Stale Component & Entity Crashes
- **Origin of Bug:** Reported when players transition through teleports into Holy Mountains (specifically the last Holy Mountain portal leading to the Laboratory / Final Boss). When transitioning biomes, Noita's engine despawns and destroys scene entities and their components.
- **Root Cause:** In `noita_api`, `try_get_first_component` was returning cached component IDs stored in `self.current_data` from when entities were spawned. When Noita's engine deleted those components mid-tick, stale component IDs remained in rust memory cache. Subsequent calls to properties on those destroyed component IDs caused `Lua error - ComponentGetValue2 couldn't find component with id: XXXX`.
- **Fix:** `try_get_first_component` and `try_get_first_component_including_disabled` in `noita_api/src/lib.rs` now query Noita's live C++ engine directly (`self.entity().try_get_first_component::<C>()`) and check entity liveness. If Noita's engine has despawned the component, `0` is returned from Noita C++ engine, which `noita_api` safely maps to `None` without invoking `ComponentGetValue2` on a deleted component.
- Added strict `entity.is_alive()` and safe `.unwrap_or(...)` handling across `diff_model.rs`, `player_fns.lua`, `inventory_helper.lua`, `player_sync.lua`, and `heart_statue.lua`.

### 2. Add "Revive on Drop" Setting for Heart Statue Mode
- Added a new `revive_on_drop` setting toggle in mod settings and `noita_proxy` host settings for Alternate (Heart Statue) local health mode.
- When enabled, dead players can be revived anywhere on the map when a living teammate picks up their Heart Statue into inventory and throws/drops it on the ground.
- Requires picking up the Heart Statue into an inventory first before dropping triggers revive, preventing instant self-revive upon death.

*P.S. The `revive_on_drop` setting is disabled by default to preserve standard multiplayer balance, but provides an optional toggle for casual / chill co-op sessions. If preferred, I can remove the toggle feature from this PR and keep only the crash fixes, just let me know!*

---

### Testing & Performance Verification
- **Dual-Machine Tested:** Thoroughly tested in multiplayer sessions across two machines (Windows 11 PC host and Fedora Linux laptop client).
- **Results:** Confirmed zero `ComponentGetValue2 couldn't find component with id` errors during teleports or Holy Mountain transitions. FPS performance remains rock-solid with no overhead.

---

### Files Modified:
- `noita_api/src/lib.rs`
- `ewext/src/modules/entity_sync/diff_model.rs`
- `noita_proxy/src/game_settings.rs`
- `noita_proxy/src/net.rs`
- `quant.ew/settings.lua`
- `quant.ew/files/system/local_health/local_health.lua`
- `quant.ew/files/core/player_fns.lua`
- `quant.ew/files/core/inventory_helper.lua`
- `quant.ew/files/system/player_sync.lua`
- `quant.ew/files/system/heart_statue/heart_statue.lua`

### Video

https://github.com/user-attachments/assets/a614193a-ac4c-49c3-be29-dcbe9f1a65d7