### PR TITLE
feat(proxy): allow domain names in direct connect

### DIFF
--- a/noita_proxy/src/app.rs
+++ b/noita_proxy/src/app.rs
@@ -1,7 +1,6 @@
 use std::{
     fmt::Display,
     fs, mem,
-    net::IpAddr,
     net::SocketAddr,
     path::PathBuf,
     process::exit,
@@ -47,6 +46,7 @@ use crate::{
         omni::{OmniPeerId, PeerVariant},
         steam_networking,
     },
+    parse_connect_addr,
     paths::{self, Paths},
     player_cosmetics::{PlayerPngDesc, display_player_skin},
     steam_helper,
@@ -784,19 +784,15 @@ impl App {
         }
 
         ui.text_edit_singleline(&mut self.app_saved_state.addr);
-        let addr = self.app_saved_state.addr.parse();
-
-        let ip: Result<IpAddr, _> = self.app_saved_state.addr.parse();
-        let addr2 = ip.map(|ip| SocketAddr::new(ip, DEFAULT_PORT));
-
-        let addr = addr.or(addr2);
-
-        ui.add_enabled_ui(addr.is_ok(), |ui| {
-            if ui.button(tr("ip_connect")).clicked()
-                && let Ok(addr) = addr
-            {
-                self.set_settings();
-                self.start_connect(addr);
+        ui.add_enabled_ui(!self.app_saved_state.addr.trim().is_empty(), |ui| {
+            if ui.button(tr("ip_connect")).clicked() {
+                match parse_connect_addr(&self.app_saved_state.addr) {
+                    Ok(addr) => {
+                        self.set_settings();
+                        self.start_connect(addr);
+                    }
+                    Err(err) => self.notify_error(err),
+                }
             }
         });
     }

--- a/noita_proxy/src/cli.rs
+++ b/noita_proxy/src/cli.rs
@@ -10,7 +10,7 @@ use crate::{
     lobby_code::{LobbyCode, LobbyKind},
     mod_manager,
     net::{NetManager, NetManagerInit, NetManagerPaths, omni::PeerVariant, steam_networking},
-    paths,
+    parse_connect_addr, paths,
     player_cosmetics::PlayerPngDesc,
     steam_helper,
     util::steam_helper::LobbyExtraData,
@@ -167,7 +167,7 @@ fn cli_setup(
 pub fn connect_cli(lobby: String, args: Args) {
     let (state, netmaninit, kind, audio, _, _) = cli_setup(args);
     let variant = if lobby.contains(':') {
-        let p = Peer::connect(lobby.parse().unwrap(), None).unwrap();
+        let p = Peer::connect(parse_connect_addr(&lobby).unwrap(), None).unwrap();
         while p.my_id().is_none() {
             sleep(Duration::from_millis(100))
         }

--- a/noita_proxy/src/lib.rs
+++ b/noita_proxy/src/lib.rs
@@ -1,4 +1,5 @@
 use std::{
+    net::{IpAddr, SocketAddr, ToSocketAddrs},
     ops::Deref,
     sync::{Arc, atomic::Ordering},
     thread::JoinHandle,
@@ -32,6 +33,28 @@ mod player_settings;
 mod cli;
 
 const DEFAULT_PORT: u16 = 5123;
+
+pub(crate) fn parse_connect_addr(raw: &str) -> eyre::Result<SocketAddr> {
+    let addr = raw.trim();
+
+    if let Ok(addr) = addr.parse::<SocketAddr>() {
+        return Ok(addr);
+    }
+
+    if let Ok(ip) = addr.parse::<IpAddr>() {
+        return Ok(SocketAddr::new(ip, DEFAULT_PORT));
+    }
+
+    let mut addrs = if addr.contains(':') {
+        addr.to_socket_addrs()?
+    } else {
+        (addr, DEFAULT_PORT).to_socket_addrs()?
+    };
+
+    addrs
+        .next()
+        .ok_or_else(|| eyre::eyre!("could not resolve address: {addr}"))
+}
 
 pub struct NetManStopOnDrop(pub Arc<net::NetManager>, Option<JoinHandle<()>>);
 


### PR DESCRIPTION
The direct IP connect UI currently validates the input as SocketAddr/IpAddr before enabling the Connect button. That rejects hostnames such as DDNS or FRP tunnel domains even though the underlying connection only needs a resolved socket address.\n\nThis changes direct connect address handling to resolve hostnames with std::net::ToSocketAddrs when the user clicks Connect. Existing inputs like 192.168.1.1:5123 and bare IP addresses continue to work, while domain.com:5123 is now accepted. Bare hostnames also use the existing default direct-connect port.\n\nThe CLI direct-connect path now reuses the same parser so GUI and CLI behavior stay consistent.\n\nI could not run cargo locally because cargo is not installed in my local environment, but this branch is formatted to match rustfmt output and should be covered by the repository CI.