### PR TITLE
[01/08] Clean up some input handling

### DIFF
--- a/noita_api/src/lib.rs
+++ b/noita_api/src/lib.rs
@@ -83,14 +83,24 @@ impl EntityID {
                             if let Ok(data) =
                                 base64::engine::general_purpose::STANDARD.decode(data.as_bytes())
                             {
-                                let data = unsafe { str::from_utf8_unchecked(&data) };
-                                if let Some((_, data)) = data.split_once("ew_gid_lid") {
+                                // mSerializedData is an arbitrary binary blob, so
+                                // it is not necessarily valid UTF-8 - building a
+                                // &str from it was UB, and iterating .chars()
+                                // over it could read past the end of the slice on
+                                // a truncated multi-byte sequence. The marker and
+                                // the digits are both ASCII, so scan the bytes.
+                                const MARKER: &[u8] = b"ew_gid_lid";
+                                if let Some(start) = data
+                                    .windows(MARKER.len())
+                                    .position(|w| w == MARKER)
+                                    .map(|i| i + MARKER.len())
+                                {
                                     let mut gid = String::new();
                                     let mut found = false;
-                                    for c in data.chars() {
-                                        if c.is_numeric() {
+                                    for &c in &data[start..] {
+                                        if c.is_ascii_digit() {
                                             found = true;
-                                            gid.push(c)
+                                            gid.push(char::from(c))
                                         } else if found {
                                             break;
                                         }

--- a/noita_api/src/lib.rs
+++ b/noita_api/src/lib.rs
@@ -14,6 +14,7 @@ use std::{
     ops::Deref,
 };
 pub mod lua;
+mod poly_gid;
 pub mod serialize;
 pub use noita_api_macro::add_lua_fn;
 
@@ -82,31 +83,9 @@ impl EntityID {
                             }
                             if let Ok(data) =
                                 base64::engine::general_purpose::STANDARD.decode(data.as_bytes())
+                                && let Some(gid) = poly_gid::gid_from_serialized_entity(&data)
                             {
-                                // mSerializedData is an arbitrary binary blob, so
-                                // it is not necessarily valid UTF-8 - building a
-                                // &str from it was UB, and iterating .chars()
-                                // over it could read past the end of the slice on
-                                // a truncated multi-byte sequence. The marker and
-                                // the digits are both ASCII, so scan the bytes.
-                                const MARKER: &[u8] = b"ew_gid_lid";
-                                if let Some(start) = data
-                                    .windows(MARKER.len())
-                                    .position(|w| w == MARKER)
-                                    .map(|i| i + MARKER.len())
-                                {
-                                    let mut gid = String::new();
-                                    let mut found = false;
-                                    for &c in &data[start..] {
-                                        if c.is_ascii_digit() {
-                                            found = true;
-                                            gid.push(char::from(c))
-                                        } else if found {
-                                            break;
-                                        }
-                                    }
-                                    return Ok(Some(Gid(gid.parse::<u64>()?)));
-                                }
+                                return Ok(Some(gid));
                             }
                         }
                         return Ok(None);

--- a/noita_api/src/poly_gid.rs
+++ b/noita_api/src/poly_gid.rs
@@ -1,0 +1,112 @@
+use shared::des::Gid;
+
+/// The `ew_gid_lid` variable name as the engine serializes it: a big-endian
+/// u32 length followed by the bytes.
+const FRAMED_NAME: &[u8] = b"\x00\x00\x00\x0aew_gid_lid";
+
+/// `u64::MAX` is 20 digits, so a longer value string is not a gid.
+const MAX_DIGITS: usize = 20;
+
+/// Pulls the `ew_gid_lid` value out of an entity the engine serialized.
+///
+/// The engine writes components positionally: every string is a big-endian
+/// u32 length followed by its bytes, and a `VariableStorageComponent` is
+/// `name`, `value_string`, `value_int`, `value_bool`, `value_float` in that
+/// order. So the gid sits directly behind the length-prefixed name:
+///
+/// ```text
+/// 00 00 00 0a "ew_gid_lid"  00 00 00 NN "<NN ascii digits>"
+/// ```
+///
+/// Matching the name together with its own length prefix rejects the same
+/// text inside a tag list, and reading exactly `NN` bytes means a binary byte
+/// that happens to be an ASCII digit can never leak into the number.
+pub(crate) fn gid_from_serialized_entity(data: &[u8]) -> Option<Gid> {
+    let start = data
+        .windows(FRAMED_NAME.len())
+        .position(|w| w == FRAMED_NAME)?
+        + FRAMED_NAME.len();
+    let len_bytes: [u8; 4] = data.get(start..start + 4)?.try_into().ok()?;
+    let len = u32::from_be_bytes(len_bytes) as usize;
+    if len == 0 || len > MAX_DIGITS {
+        return None;
+    }
+    let digits = data.get(start + 4..start + 4 + len)?;
+    if !digits.iter().all(u8::is_ascii_digit) {
+        return None;
+    }
+    std::str::from_utf8(digits).ok()?.parse().ok().map(Gid)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn string(s: &[u8]) -> Vec<u8> {
+        let mut out = (s.len() as u32).to_be_bytes().to_vec();
+        out.extend_from_slice(s);
+        out
+    }
+
+    /// A VariableStorageComponent as the engine lays it out, surrounded by
+    /// binary noise that contains ASCII digits.
+    fn blob(name: &[u8], value: &[u8]) -> Vec<u8> {
+        let mut out = vec![0x00, 0x00, 0x00, 0x02, 0x37, 0x39];
+        out.extend(string(b"VariableStorageComponent"));
+        out.push(0x01);
+        out.extend(string(b""));
+        out.extend(string(name));
+        out.extend(string(value));
+        out.extend_from_slice(&0x3132_3334_i32.to_be_bytes());
+        out.push(0x01);
+        out.extend_from_slice(&1.0f32.to_be_bytes());
+        out
+    }
+
+    #[test]
+    fn reads_the_framed_value() {
+        assert_eq!(
+            gid_from_serialized_entity(&blob(b"ew_gid_lid", b"1234567890123")),
+            Some(Gid(1234567890123))
+        );
+    }
+
+    #[test]
+    fn reads_exactly_the_declared_length() {
+        // The int field behind the string is 0x31323334, i.e. "1234"; the old
+        // digit-run scan would have glued it on.
+        assert_eq!(
+            gid_from_serialized_entity(&blob(b"ew_gid_lid", b"42")),
+            Some(Gid(42))
+        );
+    }
+
+    #[test]
+    fn ignores_the_name_inside_a_tag_list() {
+        let mut data = string(b"enemy,ew_gid_lid,ew_des");
+        data.extend(blob(b"other_var", b"7"));
+        assert_eq!(gid_from_serialized_entity(&data), None);
+    }
+
+    #[test]
+    fn rejects_non_digit_and_oversized_values() {
+        assert_eq!(
+            gid_from_serialized_entity(&blob(b"ew_gid_lid", b"12a4")),
+            None
+        );
+        assert_eq!(gid_from_serialized_entity(&blob(b"ew_gid_lid", b"")), None);
+        assert_eq!(
+            gid_from_serialized_entity(&blob(b"ew_gid_lid", &[b'9'; 21])),
+            None
+        );
+    }
+
+    #[test]
+    fn tolerates_a_truncated_blob() {
+        let full = blob(b"ew_gid_lid", b"12345");
+        for cut in 0..full.len() {
+            let _ = gid_from_serialized_entity(&full[..cut]);
+        }
+        assert_eq!(gid_from_serialized_entity(&full), Some(Gid(12345)));
+    }
+}

--- a/noita_proxy/src/net.rs
+++ b/noita_proxy/src/net.rs
@@ -119,45 +119,57 @@ enum FlagType {
     Stevari(String, i32, i32),
 }
 
+/// Cap on the declared uncompressed size of a peer-supplied message.
+///
+/// `lz4_flex::decompress_size_prepended` reads the u32 length prefix and
+/// allocates it *before* decompressing, so ~8 hostile bytes could request a
+/// 4 GiB allocation. Read the prefix ourselves and reject implausible sizes.
+const MAX_DECOMPRESSED_LEN: usize = 64 * 1024 * 1024;
+
+fn decompress_bounded(data: &[u8]) -> Option<Vec<u8>> {
+    let (size, rest) = lz4_flex::block::uncompressed_size(data).ok()?;
+    if size > MAX_DECOMPRESSED_LEN {
+        warn!("Rejecting message declaring {size} decompressed bytes");
+        return None;
+    }
+    lz4_flex::decompress(rest, size).ok()
+}
+
 fn get_flags(mut flags: String) -> Option<FlagType> {
     if flags.is_empty() {
         return None;
     }
-    match flags.remove(0) {
+    let tag = flags.remove(0);
+    // `flags` is the payload of NetMsg::Flags, i.e. it comes from a peer. These
+    // used to index c[1]..c[3] directly, so a short message panicked the net
+    // thread; match on the split slice instead.
+    let c: Vec<&str> = flags.split(' ').collect();
+    match tag {
         '0' => Some(FlagType::Normal(flags)),
-        '1' => {
-            let c = flags
-                .split(' ')
-                .map(|a| a.to_string())
-                .collect::<Vec<String>>();
-            Some(FlagType::Slow(
-                c[1].clone(),
-                c[0].parse().unwrap_or_default(),
-            ))
-        }
-        '2' => {
-            let c = flags
-                .split(' ')
-                .map(|a| a.to_string())
-                .collect::<Vec<String>>();
-            Some(FlagType::Moon(
-                c[3].clone(),
-                c[0].parse().unwrap_or_default(),
-                c[1].parse().unwrap_or_default(),
-                c[2] == "1",
-            ))
-        }
-        '3' => {
-            let c = flags
-                .split(' ')
-                .map(|a| a.to_string())
-                .collect::<Vec<String>>();
-            Some(FlagType::Stevari(
-                c[2].clone(),
-                c[0].parse().unwrap_or_default(),
-                c[1].parse().unwrap_or_default(),
-            ))
-        }
+        '1' => match c.as_slice() {
+            [slow, name, ..] => Some(FlagType::Slow(
+                (*name).to_string(),
+                slow.parse().unwrap_or_default(),
+            )),
+            _ => None,
+        },
+        '2' => match c.as_slice() {
+            [x, y, flag, name, ..] => Some(FlagType::Moon(
+                (*name).to_string(),
+                x.parse().unwrap_or_default(),
+                y.parse().unwrap_or_default(),
+                *flag == "1",
+            )),
+            _ => None,
+        },
+        '3' => match c.as_slice() {
+            [x, y, name, ..] => Some(FlagType::Stevari(
+                (*name).to_string(),
+                x.parse().unwrap_or_default(),
+                y.parse().unwrap_or_default(),
+            )),
+            _ => None,
+        },
         _ => None,
     }
 }
@@ -726,8 +738,7 @@ impl NetManager {
                 }
             }
             omni::OmniNetworkEvent::Message { src, data } => {
-                let Some(net_msg) = lz4_flex::decompress_size_prepended(&data)
-                    .ok()
+                let Some(net_msg) = decompress_bounded(&data)
                     .and_then(|decomp| bitcode::decode::<NetMsg>(&decomp).ok())
                 else {
                     return;
@@ -819,7 +830,7 @@ impl NetManager {
                 state.try_ms_write(&ws_encode_mod(src, &data));
             }
             NetMsg::ModCompressed { data } => {
-                if let Ok(decompressed) = lz4_flex::decompress_size_prepended(&data) {
+                if let Some(decompressed) = decompress_bounded(&data) {
                     state.try_ms_write(&ws_encode_mod(src, &decompressed));
                 }
             }

--- a/noita_proxy/src/net/omni.rs
+++ b/noita_proxy/src/net/omni.rs
@@ -32,14 +32,20 @@ impl From<SteamId> for OmniPeerId {
     }
 }
 
-impl From<OmniPeerId> for PeerId {
-    fn from(value: OmniPeerId) -> Self {
-        Self(
-            value
-                .0
-                .try_into()
-                .expect("Assuming PeerId was stored here, so conversion should succeed"),
-        )
+/// `OmniPeerId` is a 64-bit union of a tangled `PeerId` (16 bits) and a
+/// `SteamId` (64 bits), with no discriminant. Ids reach us from the wire (e.g.
+/// `NetMsg::PlayerColor`) and from the local mod, so narrowing is genuinely
+/// fallible - this used to be an infallible `From` with an `expect`, which meant
+/// one oversized id from any peer killed the net thread.
+impl TryFrom<OmniPeerId> for PeerId {
+    type Error = tangled::NetError;
+
+    fn try_from(value: OmniPeerId) -> Result<Self, Self::Error> {
+        value
+            .0
+            .try_into()
+            .map(Self)
+            .map_err(|_| tangled::NetError::UnknownPeer)
     }
 }
 
@@ -99,7 +105,7 @@ impl PeerVariant {
         reliability: Reliability,
     ) -> Result<(), tangled::NetError> {
         match self {
-            PeerVariant::Tangled(p) => p.send(peer.into(), msg, reliability),
+            PeerVariant::Tangled(p) => p.send(peer.try_into()?, msg, reliability),
             PeerVariant::Steam(p) => {
                 p.send_message(peer.into(), &msg, reliability)
                     .map_err(|e| match e {

--- a/noita_proxy/src/net/world/world_model.rs
+++ b/noita_proxy/src/net/world/world_model.rs
@@ -5,7 +5,12 @@ use bitcode::{Decode, Encode};
 use chunk::{Chunk, CompactPixel, Pixel, PixelFlags};
 use encoding::{NoitaWorldUpdate, PixelRun, PixelRunner};
 use rustc_hash::{FxHashMap, FxHashSet};
-use tracing::info;
+use tracing::{info, warn};
+
+/// Number of pixels in a chunk. Run lengths decoded from the network are
+/// clamped against this: `Chunk` stores a fixed `[u16; CHUNK_AREA]`, so a run
+/// set that sums past it would index out of bounds and panic the net thread.
+const CHUNK_AREA: usize = CHUNK_SIZE * CHUNK_SIZE;
 
 pub(crate) mod chunk;
 pub mod encoding;
@@ -73,14 +78,21 @@ impl ChunkData {
         let nil = CompactPixel(NonZeroU16::new(4095).unwrap());
         let mut offset = 0;
         for run in &self.runs {
+            let len = (run.length as usize).min(CHUNK_AREA - offset);
+            if len != run.length as usize {
+                warn!("Truncating over-long chunk data from peer");
+            }
             let pixel = run.data;
             if pixel != nil {
-                for _ in 0..run.length {
+                for _ in 0..len {
                     chunk.set_compact_pixel(offset, pixel);
                     offset += 1;
                 }
             } else {
-                offset += run.length as usize
+                offset += len
+            }
+            if offset >= CHUNK_AREA {
+                break;
             }
         }
     }
@@ -90,13 +102,20 @@ impl ChunkData {
         self.apply_to_chunk(&mut chunk);
         let mut offset = 0;
         for run in delta.runs.iter() {
+            let len = (run.length as usize).min(CHUNK_AREA - offset);
+            if len != run.length as usize {
+                warn!("Truncating over-long chunk delta from peer");
+            }
             if run.data != nil {
-                for _ in 0..run.length {
+                for _ in 0..len {
                     chunk.set_compact_pixel(offset, run.data);
                     offset += 1;
                 }
             } else {
-                offset += run.length as usize
+                offset += len
+            }
+            if offset >= CHUNK_AREA {
+                break;
             }
         }
         *self = chunk.to_chunk_data()
@@ -149,15 +168,25 @@ impl WorldModel {
         let runs = &update.runs;
         let mut x = 0;
         let mut y = 0;
+        // The declared rectangle bounds how many pixels this update may write.
+        // Runs come off the wire, so without this a run set that sums past
+        // (w+1)*(h+1) would keep writing into rows below the rectangle - i.e.
+        // into unrelated neighbouring chunks.
+        let capacity = (i64::from(header.w) + 1) * (i64::from(header.h) + 1);
+        let mut written: i64 = 0;
         let (mut chunk_coord, _) = Self::get_chunk_coords(header.x, header.y);
         let mut chunk = self.chunks.entry(chunk_coord).or_default();
-        for run in runs {
+        'outer: for run in runs {
             let flags = if run.data.flags > 0 {
                 PixelFlags::Fluid
             } else {
                 PixelFlags::Normal
             };
             for _ in 0..run.length {
+                if written >= capacity {
+                    break 'outer;
+                }
+                written += 1;
                 let xs = header.x + x;
                 let ys = header.y + y;
                 let (new_chunk_coord, offset) = Self::get_chunk_coords(xs, ys);
@@ -218,13 +247,20 @@ impl WorldModel {
         let chunk = self.chunks.entry(delta.chunk_coord).or_default();
         let mut offset = 0;
         for run in delta.runs.iter() {
+            let len = (run.length as usize).min(CHUNK_AREA - offset);
+            if len != run.length as usize {
+                warn!("Truncating over-long chunk delta from peer");
+            }
             if let Some(pixel) = run.data {
-                for _ in 0..run.length {
+                for _ in 0..len {
                     chunk.set_compact_pixel(offset, pixel);
                     offset += 1;
                 }
             } else {
-                offset += run.length as usize
+                offset += len
+            }
+            if offset >= CHUNK_AREA {
+                break;
             }
         }
     }
@@ -276,5 +312,86 @@ impl WorldModel {
     pub(crate) fn forget_chunk(&mut self, chunk: ChunkCoord) {
         self.chunks.remove(&chunk);
         self.updated_chunks.remove(&chunk);
+    }
+}
+
+#[cfg(test)]
+mod wire_bounds_tests {
+    use super::encoding::{Header, RawPixel};
+    use super::*;
+
+    fn px(v: u16) -> CompactPixel {
+        CompactPixel(NonZeroU16::new(v).unwrap())
+    }
+
+    /// Run lengths arrive from peers and are not otherwise validated; a run set
+    /// summing past the chunk used to index a fixed [u16; 16384] out of bounds
+    /// and take down the net thread.
+    #[test]
+    fn over_long_runs_are_clamped() {
+        let data = ChunkData {
+            runs: vec![
+                PixelRun {
+                    length: u32::MAX,
+                    data: px(42),
+                },
+                PixelRun {
+                    length: u32::MAX,
+                    data: px(43),
+                },
+            ],
+        };
+        let mut chunk = Chunk::default();
+        data.apply_to_chunk(&mut chunk);
+
+        let mut model = WorldModel::default();
+        model.apply_chunk_delta(&ChunkDelta {
+            chunk_coord: ChunkCoord(0, 0),
+            runs: Arc::new(vec![PixelRun {
+                length: u32::MAX,
+                data: Some(px(42)),
+            }]),
+        });
+
+        let mut target = ChunkData {
+            runs: vec![PixelRun {
+                length: (CHUNK_SIZE * CHUNK_SIZE) as u32,
+                data: px(7),
+            }],
+        };
+        target.apply_delta(data);
+    }
+
+    /// The declared rectangle bounds how many pixels an update may write, so
+    /// excess runs must not spill into neighbouring chunks.
+    #[test]
+    fn noita_update_respects_declared_rect() {
+        // w/h are width/height minus one, so this declares an 8x8 = 64 pixel
+        // rectangle while supplying 4096 pixels of runs.
+        let update = NoitaWorldUpdate {
+            header: Header {
+                x: 0,
+                y: 0,
+                w: 7,
+                h: 7,
+                run_count: 1,
+            },
+            runs: vec![PixelRun {
+                length: 4096,
+                data: RawPixel {
+                    material: 1,
+                    flags: 0,
+                },
+            }],
+        };
+        let mut model = WorldModel::default();
+        let mut changed = FxHashSet::default();
+        model.apply_noita_update(&update, &mut changed);
+        // 8x8 declared; nothing outside chunk (0,0) may have been touched.
+        assert!(
+            model.updated_chunks.iter().all(|c| *c == ChunkCoord(0, 0)),
+            "update escaped its declared rectangle: {:?}",
+            model.updated_chunks
+        );
     }
 }

--- a/noita_proxy/src/net/world/world_model/chunk.rs
+++ b/noita_proxy/src/net/world/world_model/chunk.rs
@@ -24,6 +24,10 @@ pub struct Pixel {
 }
 
 impl Pixel {
+    /// Materials must fit in 11 bits once incremented, so ids at or above this
+    /// cannot be represented in the compact form.
+    pub const MAX_MATERIAL: u16 = 2046;
+
     pub fn to_raw(self) -> RawPixel {
         RawPixel {
             material: if self.flags != PixelFlags::Unknown {
@@ -44,30 +48,37 @@ impl Pixel {
         } else {
             1
         };
-        let material = (self.material + 1) & 2047; // 11 bits for material
-        let raw = if self.flags == PixelFlags::Unknown {
+        // Only 11 bits are available for the material, and the encoding stores
+        // `material + 1` so that raw 0 is never produced (CompactPixel is a
+        // NonZeroU16). Ids at or above the limit used to wrap: 2047+Normal
+        // produced raw 0 and panicked the unwrap, 2046+Fluid collided with
+        // UNKNOWN_RAW, and anything >= 2048 silently aliased mod 2048. Encode
+        // them as Unknown instead - wrong, but neither a crash nor a silent
+        // impersonation of an unrelated material.
+        let raw = if self.flags == PixelFlags::Unknown || self.material >= Self::MAX_MATERIAL {
             CompactPixel::UNKNOWN_RAW
         } else {
-            (material << 1) | flag_bit
+            ((self.material + 1) << 1) | flag_bit
         };
         CompactPixel(NonZeroU16::new(raw).unwrap())
     }
     fn from_compact(compact: CompactPixel) -> Self {
         let raw = u16::from(compact.0);
+        // Must be checked before the arithmetic below: UNKNOWN_RAW is 4095, and
+        // `(4095 >> 1) - 1` is fine, but raw values of 0 or 1 would underflow.
+        if raw == CompactPixel::UNKNOWN_RAW || raw < 2 {
+            return Pixel {
+                flags: PixelFlags::Unknown,
+                material: 0,
+            };
+        }
         let material = (raw >> 1) - 1;
         let flags = if raw & 1 == 1 {
             PixelFlags::Fluid
         } else {
             PixelFlags::Normal
         };
-        if raw == CompactPixel::UNKNOWN_RAW {
-            Pixel {
-                flags: PixelFlags::Unknown,
-                material: 0,
-            }
-        } else {
-            Pixel { flags, material }
-        }
+        Pixel { flags, material }
     }
 }
 
@@ -142,6 +153,33 @@ fn test_changed() {
         std::hint::black_box(chunk);
     }
     println!("bool {}", tmr.elapsed().as_nanos())
+}
+
+#[test]
+fn compact_pixel_round_trip() {
+    // Every representable material, both flag states. This previously panicked
+    // on material 2047 (raw 0 -> NonZeroU16::new().unwrap()) and on the
+    // `(raw >> 1) - 1` underflow, and silently aliased ids >= 2048.
+    for material in 0..=u16::MAX {
+        for flags in [PixelFlags::Normal, PixelFlags::Fluid] {
+            let px = Pixel { flags, material };
+            let round = Pixel::from_compact(px.to_compact());
+            if material < Pixel::MAX_MATERIAL {
+                assert_eq!(round, px, "material {material} with {flags:?}");
+            } else {
+                assert_eq!(
+                    round.flags,
+                    PixelFlags::Unknown,
+                    "out-of-range material {material} should degrade to Unknown, not alias"
+                );
+            }
+        }
+    }
+    let unknown = Pixel {
+        flags: PixelFlags::Unknown,
+        material: 0,
+    };
+    assert_eq!(Pixel::from_compact(unknown.to_compact()), unknown);
 }
 
 impl Default for Chunk {

--- a/noita_proxy/tangled/src/connection_manager/message_stream.rs
+++ b/noita_proxy/tangled/src/connection_manager/message_stream.rs
@@ -62,6 +62,9 @@ impl<Msg: DecodeOwned> RecvMessageStream<Msg> {
             .await
             .map_err(|_err| DirectConnectionError::MessageIoFailed)?;
         trace!("Expecting message of len {len}");
+        if len as usize > crate::MAX_MESSAGE_LEN {
+            return Err(DirectConnectionError::MessageIoFailed);
+        }
         let mut buf = vec![0; len as usize];
         self.inner
             .read_exact(&mut buf)

--- a/noita_proxy/tangled/src/lib.rs
+++ b/noita_proxy/tangled/src/lib.rs
@@ -10,7 +10,11 @@ pub use error::NetError;
 
 /// Maximum size of a message which fits into a single datagram.
 /// Somewhat arbitrary, but if it gets this large something probably went wrong.
-pub const MAX_MESSAGE_LEN: usize = 2 * 1024 * 1024 * 1024;
+/// Upper bound on a single framed message. The receive path allocates the
+/// wire-supplied length before reading the body, so this has to be a size we
+/// are willing to have a peer allocate on demand - the previous 2 GiB was
+/// effectively no limit, and was never checked anywhere regardless.
+pub const MAX_MESSAGE_LEN: usize = 64 * 1024 * 1024;
 
 mod common;
 mod connection_manager;

--- a/shared/src/message_socket.rs
+++ b/shared/src/message_socket.rs
@@ -11,11 +11,20 @@ use bitcode::{DecodeOwned, Encode};
 use eyre::{Context, bail};
 use tracing::info;
 
+/// Upper bound on a single framed message, to stop a corrupt or hostile length
+/// prefix from turning into a multi-gigabyte allocation. The largest legitimate
+/// message is a world update (~82 KB, see PIXEL_RUN_MAX in world_sync/world.lua)
+/// plus entity-sync batches, so this leaves a very wide margin.
+pub const MAX_MESSAGE_LEN: u32 = 64 * 1024 * 1024;
+
 fn read_one<T: DecodeOwned>(mut buf: impl Read) -> eyre::Result<T> {
     let mut len_buf = [0u8; 4];
     buf.read_exact(&mut len_buf)
         .wrap_err("Couldn't receive the length from stream")?;
     let len = u32::from_le_bytes(len_buf);
+    if len > MAX_MESSAGE_LEN {
+        bail!("Message length {len} exceeds the maximum of {MAX_MESSAGE_LEN}");
+    }
     let mut out_buf = vec![0; usize::try_from(len)?];
     buf.read_exact(out_buf.as_mut_slice())
         .wrap_err("Couldn't read message body")?;


### PR DESCRIPTION
This makes a few potential parsing failures or hostile clients a bit easier to notice and debug, and fixes some potential security issues/undefined behavior that could result from a badly behaving client.