### PR TITLE
[04/08] Entity Cache and syncing changes

### DIFF
--- a/ewext/src/lib.rs
+++ b/ewext/src/lib.rs
@@ -745,24 +745,24 @@ pub unsafe extern "C" fn luaopen_ewext(lua: *mut lua_State) -> c_int {
                     .modules
                     .entity_sync
                     .as_mut()
-                    .unwrap()
+                    .ok_or_eyre("No entity sync module loaded")?
                     .set_perf(lua.to_bool(1));
                 Ok(())
             })?
         }
         add_lua_fn!(set_log);
-        fn set_cache(lua: LuaState) -> eyre::Result<()> {
+        fn set_bypass_cache(lua: LuaState) -> eyre::Result<()> {
             ExtState::with_global(|state| {
                 state
                     .modules
                     .entity_sync
                     .as_mut()
-                    .unwrap()
-                    .set_cache(lua.to_bool(1));
+                    .ok_or_eyre("No entity sync module loaded")?
+                    .set_bypass_cache(lua.to_bool(1));
                 Ok(())
             })?
         }
-        add_lua_fn!(set_cache);
+        add_lua_fn!(set_bypass_cache);
     }
     #[cfg(debug_assertions)]
     println!("Initializing ewext - Ok");

--- a/ewext/src/modules/entity_sync.rs
+++ b/ewext/src/modules/entity_sync.rs
@@ -159,7 +159,7 @@ impl EntitySync {
         } else {
             Ok(())
         };
-        if !self.local_diff_model.update_buffer.is_empty() {
+        let err2 = if !self.local_diff_model.update_buffer.is_empty() {
             let res = std::mem::take(&mut self.local_diff_model.update_buffer);
             let (RemoteDes::EntityUpdate(diff), err) = send_remotedes_ret(
                 ctx,
@@ -175,9 +175,15 @@ impl EntitySync {
                 unreachable!()
             };
             self.local_diff_model.update_buffer = diff;
-            err1?;
-            err?;
-        }
+            err
+        } else {
+            Ok(())
+        };
+        // Both sends have to be attempted before either error escapes - each one
+        // puts back the buffer it took, so bailing out early would drop the
+        // other buffer's diffs on the floor.
+        err1?;
+        err2?;
         Ok(())
     }
     pub(crate) fn spawn_once(
@@ -675,7 +681,9 @@ impl Module for EntitySync {
             {
                 Ok(ret) => ret,
                 Err(s) => {
-                    self.clear_buffer(ctx, &new_intersects)?;
+                    // Flushing is best effort here - a send failure must not
+                    // displace s, which is the error that explains the frame.
+                    let _ = self.clear_buffer(ctx, &new_intersects);
                     return Err(s);
                 }
             };

--- a/ewext/src/modules/entity_sync.rs
+++ b/ewext/src/modules/entity_sync.rs
@@ -21,9 +21,11 @@ use shared::{
     Destination, NoitaOutbound, PeerId, RemoteMessage, WorldPos,
     des::{Gid, InterestRequest, ProjectileFired, RemoteDes},
 };
+use sprite_animations::SpriteAnimations;
 use std::sync::{LazyLock, Mutex};
 mod diff_model;
 mod interest;
+mod sprite_animations;
 
 static ENTITY_EXCLUDES: LazyLock<FxHashSet<&'static str>> = LazyLock::new(|| {
     let mut hs = FxHashSet::default();
@@ -58,6 +60,7 @@ pub(crate) struct EntitySync {
     peer_order: Vec<PeerId>,
     log_performance: bool,
     entity_manager: EntityManager,
+    sprite_animations: SpriteAnimations,
 }
 impl EntitySync {
     pub(crate) fn set_perf(&mut self, perf: bool) {
@@ -113,6 +116,7 @@ impl Default for EntitySync {
             peer_order: Vec::new(),
             log_performance: false,
             entity_manager: EntityManager::default(),
+            sprite_animations: SpriteAnimations::default(),
         }
     }
 }
@@ -667,7 +671,13 @@ impl Module for EntitySync {
             let dead;
             (dead, self.local_index) = match self
                 .local_diff_model
-                .update_tracked_entities(ctx, self.local_index, start, &mut self.entity_manager)
+                .update_tracked_entities(
+                    ctx,
+                    self.local_index,
+                    start,
+                    &mut self.entity_manager,
+                    &mut self.sprite_animations,
+                )
                 .wrap_err("Failed to update locally tracked entities")
             {
                 Ok(ret) => ret,
@@ -751,7 +761,13 @@ impl Module for EntitySync {
                     Some(remote_model) => {
                         let vi = self.remote_index.entry(*owner).or_insert(0);
                         let v = remote_model
-                            .apply_entities(ctx, *vi, start, &mut self.entity_manager)
+                            .apply_entities(
+                                ctx,
+                                *vi,
+                                start,
+                                &mut self.entity_manager,
+                                &mut self.sprite_animations,
+                            )
                             .wrap_err("Failed to apply entity infos")?;
                         self.remote_index.insert(*owner, v);
                         if self.log_performance {

--- a/ewext/src/modules/entity_sync.rs
+++ b/ewext/src/modules/entity_sync.rs
@@ -63,8 +63,8 @@ impl EntitySync {
     pub(crate) fn set_perf(&mut self, perf: bool) {
         self.log_performance = perf;
     }
-    pub(crate) fn set_cache(&mut self, cache: bool) {
-        self.entity_manager.set_cache(cache);
+    pub(crate) fn set_bypass_cache(&mut self, bypass: bool) {
+        self.entity_manager.set_bypass_cache(bypass);
     }
     /*pub(crate) fn has_gid(&self, gid: Gid) -> bool {
         self.local_diff_model.has_gid(gid) || self.remote_models.values().any(|r| r.has_gid(gid))

--- a/ewext/src/modules/entity_sync.rs
+++ b/ewext/src/modules/entity_sync.rs
@@ -565,23 +565,14 @@ impl Module for EntitySync {
                 if self
                     .entity_manager
                     .has_tag(const { CachedTag::from_tag("card_action") })
-                {
-                    if let Some(cost) = self
+                    && let Some(cost) = self
                         .entity_manager
                         .try_get_first_component::<ItemCostComponent>(ComponentTag::None)
-                        && cost.stealable()?
-                    {
-                        cost.set_stealable(false)?;
-                        self.entity_manager
-                            .get_var_or_default(const { VarName::from_str("ew_was_stealable") })?;
-                    }
-                    if let Some(vel) = self
-                        .entity_manager
-                        .try_get_first_component::<VelocityComponent>(ComponentTag::None)
-                    {
-                        vel.set_gravity_y(0.0)?;
-                        vel.set_air_friction(10.0)?;
-                    }
+                    && cost.stealable()?
+                {
+                    cost.set_stealable(false)?;
+                    self.entity_manager
+                        .get_var_or_default(const { VarName::from_str("ew_was_stealable") })?;
                 }
                 self.to_track.push(entity);
             }

--- a/ewext/src/modules/entity_sync.rs
+++ b/ewext/src/modules/entity_sync.rs
@@ -545,13 +545,10 @@ impl Module for EntitySync {
             self.local_diff_model.got_polied(gid);
         }
         if self.should_be_tracked(entity)? {
-            self.entity_manager.set_current_entity(entity)?;
-            if self
-                .entity_manager
-                .has_tag(const { CachedTag::from_tag(DES_TAG) })
+            let mut handle = self.entity_manager.handle(entity)?;
+            if handle.has_tag(const { CachedTag::from_tag(DES_TAG) })
                 && !self.dont_kill.remove(&entity)
-                && self
-                    .entity_manager
+                && handle
                     .get_var(const { VarName::from_str("ew_gid_lid") })
                     .map(|var| {
                         if let Ok(n) = var.value_string().unwrap_or("NA".into()).parse::<u64>() {
@@ -566,17 +563,13 @@ impl Module for EntitySync {
                     entity.kill();
                 }
             } else {
-                if self
-                    .entity_manager
-                    .has_tag(const { CachedTag::from_tag("card_action") })
-                    && let Some(cost) = self
-                        .entity_manager
-                        .try_get_first_component::<ItemCostComponent>(ComponentTag::None)
+                if handle.has_tag(const { CachedTag::from_tag("card_action") })
+                    && let Some(cost) =
+                        handle.try_get_first_component::<ItemCostComponent>(ComponentTag::None)
                     && cost.stealable()?
                 {
                     cost.set_stealable(false)?;
-                    self.entity_manager
-                        .get_var_or_default(const { VarName::from_str("ew_was_stealable") })?;
+                    handle.get_var_or_default(const { VarName::from_str("ew_was_stealable") })?;
                 }
                 self.to_track.push(entity);
             }

--- a/ewext/src/modules/entity_sync/diff_model.rs
+++ b/ewext/src/modules/entity_sync/diff_model.rs
@@ -9,7 +9,7 @@ use noita_api::{
     AIAttackComponent, AbilityComponent, AdvancedFishAIComponent, AnimalAIComponent,
     AudioComponent, BossDragonComponent, BossHealthBarComponent, CachedTag, CameraBoundComponent,
     CharacterDataComponent, CharacterPlatformingComponent, ComponentTag, DamageModelComponent,
-    DamageType, EntityID, EntityManager, ExplodeOnDamageComponent, GhostComponent,
+    DamageType, EntityHandle, EntityID, EntityManager, ExplodeOnDamageComponent, GhostComponent,
     IKLimbAttackerComponent, IKLimbComponent, IKLimbWalkerComponent, IKLimbsAnimatorComponent,
     Inventory2Component, ItemComponent, ItemCostComponent, ItemPickUpperComponent,
     LaserEmitterComponent, LifetimeComponent, LuaComponent, PhysData, PhysicsAIComponent,
@@ -220,8 +220,7 @@ impl RemoteDiffModel {
     }
     pub(crate) fn remove_entities(self, entity_manager: &mut EntityManager) -> eyre::Result<()> {
         for (_, ent) in self.tracked.into_iter() {
-            entity_manager.set_current_entity(ent)?;
-            safe_entitykill(entity_manager);
+            safe_entitykill(entity_manager.handle(ent)?);
         }
         Ok(())
     }
@@ -275,7 +274,7 @@ impl LocalDiffModelTracker {
         let entity = self
             .entity_by_lid(lid)
             .wrap_err_with(|| eyre!("Failed to grab update info for {:?} {:?}", gid, lid))?;
-        entity_manager.set_current_entity(entity)?;
+        let mut handle = entity_manager.handle(entity)?;
 
         if !entity.is_alive() {
             if self.got_polied.remove(&gid) {
@@ -299,13 +298,13 @@ impl LocalDiffModelTracker {
         }
         let item_and_was_picked = info.kind == EntityKind::Item && item_in_inventory(entity)?;
         if item_and_was_picked && not_in_player_inventory(entity)? {
-            self.temporary_untrack_item(ctx, gid, lid, entity, entity_manager)?;
+            self.temporary_untrack_item(ctx, gid, lid, &mut handle)?;
             return Ok(false);
         }
 
         let (x, y, r, sx, sy) = entity.transform()?;
         let should_send_position = if let Some(com) =
-            entity_manager.try_get_first_component::<ItemComponent>(ComponentTag::None)
+            handle.try_get_first_component::<ItemComponent>(ComponentTag::None)
         {
             !com.play_hover_animation()?
         } else {
@@ -317,7 +316,7 @@ impl LocalDiffModelTracker {
         }
 
         let should_send_rotation = if let Some(com) =
-            entity_manager.try_get_first_component::<ItemComponent>(ComponentTag::None)
+            handle.try_get_first_component::<ItemComponent>(ComponentTag::None)
         {
             !com.play_spinning_animation()? || com.play_hover_animation()?
         } else {
@@ -328,7 +327,7 @@ impl LocalDiffModelTracker {
             info.r = r as f32
         }
 
-        if let Some(inv) = entity_manager
+        if let Some(inv) = handle
             .try_get_first_component_including_disabled::<Inventory2Component>(ComponentTag::None)
         {
             if let Some(wand) = inv.m_actual_active_item()? {
@@ -363,18 +362,18 @@ impl LocalDiffModelTracker {
                 info.wand = None;
             };
         }
-        info.is_enabled = (entity_manager.has_tag(const { CachedTag::from_tag("boss_centipede") })
-            && entity_manager
+        info.is_enabled = (handle.has_tag(const { CachedTag::from_tag("boss_centipede") })
+            && handle
                 .try_get_first_component::<BossHealthBarComponent>(
                     const { ComponentTag::from_str("disabled_at_start") },
                 )
                 .is_some())
-            || entity_manager
+            || handle
                 .get_var(const { VarName::from_str("active") })
                 .map(|var| var.value_int().unwrap_or(0) == 1)
                 .unwrap_or(false)
-            || (entity_manager.has_tag(const { CachedTag::from_tag("pitcheck_b") })
-                && entity_manager
+            || (handle.has_tag(const { CachedTag::from_tag("pitcheck_b") })
+                && handle
                     .try_get_first_component::<LuaComponent>(
                         const { ComponentTag::from_str("disabled") },
                     )
@@ -392,44 +391,44 @@ impl LocalDiffModelTracker {
             .collect();
 
         if let Some(worm) =
-            entity_manager.try_get_first_component::<BossDragonComponent>(ComponentTag::None)
+            handle.try_get_first_component::<BossDragonComponent>(ComponentTag::None)
         {
             (info.vx, info.vy) = worm.m_target_vec()?;
         } else if let Some(worm) =
-            entity_manager.try_get_first_component::<WormComponent>(ComponentTag::None)
+            handle.try_get_first_component::<WormComponent>(ComponentTag::None)
         {
             (info.vx, info.vy) = worm.m_target_vec()?;
         } else if let Some(vel) =
-            entity_manager.try_get_first_component::<CharacterDataComponent>(ComponentTag::None)
+            handle.try_get_first_component::<CharacterDataComponent>(ComponentTag::None)
         {
             (info.vx, info.vy) = vel.m_velocity()?;
         } else if let Some(vel) =
-            entity_manager.try_get_first_component::<VelocityComponent>(ComponentTag::None)
+            handle.try_get_first_component::<VelocityComponent>(ComponentTag::None)
         {
             (info.vx, info.vy) = vel.m_velocity()?;
         }
 
         if info.kind == EntityKind::Item && !item_and_was_picked {
-            hold_over_ungenerated_world(entity_manager, x, y)?;
+            hold_over_ungenerated_world(&mut handle, x, y)?;
         }
 
         if let Some(damage) =
-            entity_manager.try_get_first_component::<DamageModelComponent>(ComponentTag::None)
+            handle.try_get_first_component::<DamageModelComponent>(ComponentTag::None)
         {
             let hp = damage.hp()?;
             info.hp = hp as f32;
         }
 
-        if entity_manager.check_all_phys_init()? {
+        if handle.check_all_phys_init()? {
             info.phys = collect_phys_info(entity)?;
         }
 
         if let Some(item_cost) =
-            entity_manager.try_get_first_component::<ItemCostComponent>(ComponentTag::None)
+            handle.try_get_first_component::<ItemCostComponent>(ComponentTag::None)
         {
             info.cost = item_cost.cost()?;
-        } else if entity_manager.has_tag(const { CachedTag::from_tag("boss_wizard") }) {
-            info.cost = entity_manager.frame_num() as i64;
+        } else if handle.has_tag(const { CachedTag::from_tag("boss_wizard") }) {
+            info.cost = handle.frame_num() as i64;
             info.counter = entity
                 .children(None)
                 .filter_map(|ent| {
@@ -452,10 +451,10 @@ impl LocalDiffModelTracker {
         } else {
             info.cost = 0;
         }
-        if entity_manager.has_tag(const { CachedTag::from_tag("seed_d") }) {
-            let essences = entity_manager
-                .get_var_or_default(const { VarName::from_str("sunbaby_essences_list") })?;
-            let sprite = entity_manager.get_first_component::<SpriteComponent>(
+        if handle.has_tag(const { CachedTag::from_tag("seed_d") }) {
+            let essences =
+                handle.get_var_or_default(const { VarName::from_str("sunbaby_essences_list") })?;
+            let sprite = handle.get_first_component::<SpriteComponent>(
                 const { ComponentTag::from_str("sunbaby_sprite") },
             )?;
             let sprite = sprite.image_file()?;
@@ -489,11 +488,10 @@ impl LocalDiffModelTracker {
             .collect::<Vec<GameEffectData>>();
 
         info.current_stains =
-            if let Some(var) = entity_manager.get_var(const { VarName::from_str("rolling") }) {
+            if let Some(var) = handle.get_var(const { VarName::from_str("rolling") }) {
                 if var.value_int()? == 0 {
                     let rng = rand::random::<i32>();
-                    let var =
-                        entity_manager.get_var_or_default(const { VarName::from_str("ew_rng") })?;
+                    let var = handle.get_var_or_default(const { VarName::from_str("ew_rng") })?;
                     var.set_value_int(rng)?;
                     let bytes = rng.to_le_bytes();
                     u64::from_le_bytes([0, 0, 0, 0, bytes[0], bytes[1], bytes[2], bytes[3]])
@@ -506,30 +504,29 @@ impl LocalDiffModelTracker {
                     }
                 }
             } else {
-                entity_manager.get_current_stains()?
+                handle.get_current_stains()?
             };
 
         let mut any = false;
-        for ai in entity_manager
+        for ai in handle
             .iter_all_components_of_type_including_disabled::<AIAttackComponent>(ComponentTag::None)
         {
             any = any || ai.attack_ranged_aim_rotation_enabled()?;
         }
-        for ai in entity_manager
+        for ai in handle
             .iter_all_components_of_type_including_disabled::<AnimalAIComponent>(ComponentTag::None)
         {
             any = any || ai.attack_ranged_aim_rotation_enabled()?;
         }
         if any {
-            if let Some(ai) = entity_manager
+            if let Some(ai) = handle
                 .try_get_first_component_including_disabled::<AnimalAIComponent>(ComponentTag::None)
             {
                 info.ai_state = ai.ai_state()?;
                 info.ai_rotation = ai.m_ranged_attack_current_aim_angle()?;
             }
         } else {
-            let sprites =
-                entity_manager.iter_all_components_of_type::<SpriteComponent>(ComponentTag::None);
+            let sprites = handle.iter_all_components_of_type::<SpriteComponent>(ComponentTag::None);
             info.facing_direction = (sx.is_sign_positive(), sy.is_sign_positive());
             info.animations = sprites
                 .filter_map(|sprite| {
@@ -543,7 +540,7 @@ impl LocalDiffModelTracker {
                 })
                 .collect();
             if let Some(ai) =
-                entity_manager.try_get_first_component::<AnimalAIComponent>(ComponentTag::None)
+                handle.try_get_first_component::<AnimalAIComponent>(ComponentTag::None)
                 && ai.attack_ranged_use_laser_sight()?
                 && !ai.is_static_turret()?
             {
@@ -567,7 +564,7 @@ impl LocalDiffModelTracker {
             }
         }
 
-        info.synced_var = entity_manager
+        info.synced_var = handle
             .iter_all_components_of_type_including_disabled::<VariableStorageComponent>(
                 const { ComponentTag::from_str("ew_synced_var") },
             )
@@ -601,19 +598,11 @@ impl LocalDiffModelTracker {
                         TRANSFER_RADIUS
                     },
                 )? {
-                    self.transfer_authority_to(
-                        ctx,
-                        gid,
-                        lid,
-                        peer,
-                        info,
-                        do_upload,
-                        entity_manager,
-                    )
-                    .wrap_err("Failed to transfer authority")?;
+                    self.transfer_authority_to(ctx, gid, lid, peer, info, do_upload, handle)
+                        .wrap_err("Failed to transfer authority")?;
                     return Ok(do_upload);
                 } else if !info.is_global && is_beyond_authority {
-                    self.release_authority(ctx, gid, lid, info, do_upload, entity_manager)
+                    self.release_authority(ctx, gid, lid, info, do_upload, handle)
                         .wrap_err("Failed to release authority")?;
                     return Ok(do_upload);
                 }
@@ -624,16 +613,16 @@ impl LocalDiffModelTracker {
         // not there was anything under it yet. hold_over_ungenerated_world above
         // waits for the terrain instead; this only decides when a shop item
         // becomes stealable again.
-        if let Some(var) = entity_manager.get_var(const { VarName::from_str("ew_was_stealable") }) {
+        if let Some(var) = handle.get_var(const { VarName::from_str("ew_was_stealable") }) {
             let n = var.value_int()?;
             if n == 1 {
                 if let Some(cost) =
-                    entity_manager.try_get_first_component::<ItemCostComponent>(ComponentTag::None)
+                    handle.try_get_first_component::<ItemCostComponent>(ComponentTag::None)
                 {
-                    let (cx, cy) = entity_manager.camera_pos();
+                    let (cx, cy) = handle.camera_pos();
                     if ((cx - x) as f32).powi(2) + ((cy - y) as f32).powi(2) < 256.0 * 256.0 {
                         cost.set_stealable(true)?;
-                        entity_manager.remove_component(var)?;
+                        handle.remove_component(var)?;
                     }
                 }
             } else if n == 0 {
@@ -664,12 +653,12 @@ impl LocalDiffModelTracker {
         ctx: &mut ModuleCtx<'_>,
         gid: Gid,
         lid: Lid,
-        entity: EntityID,
-        entity_manager: &mut EntityManager,
+        handle: &mut EntityHandle,
     ) -> Result<(), eyre::Error> {
+        let entity = handle.entity();
         self.untrack_entity(ctx, gid, lid, Some(entity.0))?;
-        entity_manager.remove_tag(const { CachedTag::from_tag(DES_TAG) })?;
-        with_entity_scripts(entity_manager, |luac| {
+        handle.remove_tag(const { CachedTag::from_tag(DES_TAG) })?;
+        with_entity_scripts(handle, |luac| {
             luac.set_script_throw_item(
                 "mods/quant.ew/files/system/entity_sync_helper/item_notify.lua".into(),
             )
@@ -749,15 +738,14 @@ impl LocalDiffModelTracker {
         lid: Lid,
         info: &EntityInfo,
         do_upload: bool,
-        entity_manager: &mut EntityManager,
+        handle: EntityHandle,
     ) -> eyre::Result<()> {
-        let entity = self._release_authority_update_data(ctx, gid, lid, info, do_upload)?;
+        self._release_authority_update_data(ctx, gid, lid, info, do_upload)?;
         ctx.net.send(&NoitaOutbound::DesToProxy(
             shared::des::DesToProxy::ReleaseAuthority(gid),
         ))?;
         self.pending_removal.push(lid);
-        entity_manager.set_current_entity(entity)?;
-        safe_entitykill(entity_manager);
+        safe_entitykill(handle);
         Ok(())
     }
 
@@ -770,15 +758,14 @@ impl LocalDiffModelTracker {
         peer: PeerId,
         info: &EntityInfo,
         do_upload: bool,
-        entity_manager: &mut EntityManager,
+        handle: EntityHandle,
     ) -> eyre::Result<()> {
-        let entity = self._release_authority_update_data(ctx, gid, lid, info, do_upload)?;
+        self._release_authority_update_data(ctx, gid, lid, info, do_upload)?;
         ctx.net.send(&NoitaOutbound::DesToProxy(
             shared::des::DesToProxy::TransferAuthorityTo(gid, peer),
         ))?;
         self.pending_removal.push(lid);
-        entity_manager.set_current_entity(entity)?;
-        safe_entitykill(entity_manager);
+        safe_entitykill(handle);
         Ok(())
     }
 }
@@ -796,37 +783,37 @@ impl LocalDiffModel {
         gid: Gid,
         entity_manager: &mut EntityManager,
     ) -> eyre::Result<Lid> {
-        entity_manager.set_current_entity(entity)?;
+        let mut handle = entity_manager.handle(entity)?;
         self.wait_to_transfer = 16;
         let lid = self.alloc_lid();
-        let should_not_serialize = entity_manager
+        let should_not_serialize = handle
             .remove_all_components_of_type::<CameraBoundComponent>(ComponentTag::None)?
-            || (entity.is_alive() && entity_manager.check_all_phys_init()? && entity.get_physics_body_ids().unwrap_or_default()
+            || (entity.is_alive() && handle.check_all_phys_init()? && entity.get_physics_body_ids().unwrap_or_default()
                 .len()
-                == entity_manager
+                == handle
                     .iter_all_components_of_type_including_disabled::<PhysicsBodyComponent>(ComponentTag::None)
                     .count()
-                    + entity_manager
+                    + handle
                         .iter_all_components_of_type_including_disabled::<PhysicsBody2Component>(
                             ComponentTag::None,
                         )
                         .count());
-        entity_manager.add_tag(const { CachedTag::from_tag(DES_TAG) })?;
-        if let Some(ghost) = entity_manager
-            .try_get_first_component_including_disabled::<GhostComponent>(ComponentTag::None)
+        handle.add_tag(const { CachedTag::from_tag(DES_TAG) })?;
+        if let Some(ghost) =
+            handle.try_get_first_component_including_disabled::<GhostComponent>(ComponentTag::None)
         {
             ghost.set_target_tag("".into())?;
         }
 
         let (x, y) = entity.position()?;
 
-        if entity_manager.has_tag(const { CachedTag::from_tag("card_action") })
+        if handle.has_tag(const { CachedTag::from_tag("card_action") })
             && let Some(cost) =
-                entity_manager.try_get_first_component::<ItemCostComponent>(ComponentTag::None)
+                handle.try_get_first_component::<ItemCostComponent>(ComponentTag::None)
             && cost.stealable()?
         {
             cost.set_stealable(false)?;
-            entity_manager.get_var_or_default(const { VarName::from_str("ew_was_stealable") })?;
+            handle.get_var_or_default(const { VarName::from_str("ew_was_stealable") })?;
         }
 
         let entity_kind = classify_entity(entity)?;
@@ -839,16 +826,15 @@ impl LocalDiffModel {
                 data: serialize_entity(entity)?, //TODO we never update this?
             },
         };
-        with_entity_scripts(entity_manager, |scripts| {
+        with_entity_scripts(&mut handle, |scripts| {
             scripts.set_script_death(
                 "mods/quant.ew/files/system/entity_sync_helper/death_notify.lua".into(),
             )
         })?;
-        if let Some(lua) = entity_manager.get_var(const { VarName::from_str("ew_gid_lid") }) {
-            entity_manager.remove_component(lua)?;
+        if let Some(lua) = handle.get_var(const { VarName::from_str("ew_gid_lid") }) {
+            handle.remove_component(lua)?;
         }
-        let var = entity_manager
-            .add_component_with_var_name(const { VarName::from_str("ew_gid_lid") })?;
+        let var = handle.add_component_with_var_name(const { VarName::from_str("ew_gid_lid") })?;
         var.set_value_string(gid.0.to_string().into())?;
         var.set_value_int(i32::from_le_bytes(lid.0.to_le_bytes()))?;
         var.set_value_bool(true)?;
@@ -856,44 +842,44 @@ impl LocalDiffModel {
         // Must come after spawn_info was serialized above, or every peer that
         // later spawns this item from that data inherits the disabled physics.
         if entity_kind == EntityKind::Item && !item_in_inventory(entity)? {
-            hold_over_ungenerated_world(entity_manager, x, y)?;
+            hold_over_ungenerated_world(&mut handle, x, y)?;
         }
 
-        if entity_manager
+        if handle
             .try_get_first_component::<BossDragonComponent>(ComponentTag::None)
             .is_some()
-            && entity_manager
+            && handle
                 .try_get_first_component::<StreamingKeepAliveComponent>(ComponentTag::None)
                 .is_none()
         {
-            entity_manager.add_component::<StreamingKeepAliveComponent>()?;
+            handle.add_component::<StreamingKeepAliveComponent>()?;
         }
 
-        let is_global = entity_manager
+        let is_global = handle
             .try_get_first_component_including_disabled::<BossHealthBarComponent>(
                 ComponentTag::None,
             )
             .is_some()
-            || entity_manager
+            || handle
                 .try_get_first_component::<StreamingKeepAliveComponent>(ComponentTag::None)
                 .is_some();
 
-        let drops_gold = (entity_manager
+        let drops_gold = (handle
             .iter_all_components_of_type::<LuaComponent>(ComponentTag::None)
             .any(|lua| {
                 lua.script_death().ok() == Some("data/scripts/items/drop_money.lua".into())
             })
-            && entity_manager
+            && handle
                 .iter_all_components_of_type::<VariableStorageComponent>(ComponentTag::None)
                 .all(|var| !var.has_tag("no_gold_drop")))
-            || (entity_manager.has_tag(const { CachedTag::from_tag("boss_dragon") })
-                && entity_manager
+            || (handle.has_tag(const { CachedTag::from_tag("boss_dragon") })
+                && handle
                     .iter_all_components_of_type::<LuaComponent>(ComponentTag::None)
                     .any(|lua| {
                         lua.script_death().ok()
                             == Some("data/scripts/animals/boss_dragon_death.lua".into())
                     }))
-            || entity_manager
+            || handle
                 .get_var(const { VarName::from_str("throw_time") })
                 .map(|v| v.value_int().ok() != Some(-1))
                 .unwrap_or(false);
@@ -958,8 +944,8 @@ impl LocalDiffModel {
 
     pub(crate) fn phys_later(&mut self, entity_manager: &mut EntityManager) -> eyre::Result<()> {
         for (entity, phys) in self.phys_later.drain(..) {
-            entity_manager.set_current_entity(entity)?;
-            if entity.is_alive() && entity_manager.check_all_phys_init()? {
+            let mut handle = entity_manager.handle(entity)?;
+            if entity.is_alive() && handle.check_all_phys_init()? {
                 let phys_bodies = entity.get_physics_body_ids().unwrap_or_default();
                 for (p, physics_body_id) in phys.iter().zip(phys_bodies.iter()) {
                     let Some(p) = p else {
@@ -984,19 +970,19 @@ impl LocalDiffModel {
     pub(crate) fn enable_later(&mut self, entity_manager: &mut EntityManager) -> eyre::Result<()> {
         for entity in self.enable_later.drain(..) {
             if entity.is_alive() {
-                entity_manager.set_current_entity(entity)?;
-                entity_manager.set_components_with_tag_enabled(
+                let mut handle = entity_manager.handle(entity)?;
+                handle.set_components_with_tag_enabled(
                     const { ComponentTag::from_str("disabled_at_start") },
                     true,
                 )?;
-                entity_manager.set_components_with_tag_enabled(
+                handle.set_components_with_tag_enabled(
                     const { ComponentTag::from_str("enabled_at_start") },
                     false,
                 )?;
                 entity
                     .children(Some("protection".into()))
                     .for_each(|ent| ent.kill());
-                entity_manager.add_tag(const { CachedTag::from_tag("boss_centipede_active") })?;
+                handle.add_tag(const { CachedTag::from_tag("boss_centipede_active") })?;
                 entity.set_static(false)?
             }
         }
@@ -1009,25 +995,24 @@ impl LocalDiffModel {
         entity_manager: &mut EntityManager,
     ) -> eyre::Result<Instant> {
         while let Some(entity_data) = self.tracker.pending_authority.pop() {
-            let entity = spawn_entity_by_data(
+            let mut handle = spawn_entity_by_data(
                 &entity_data.data,
                 entity_data.pos.x as f32,
                 entity_data.pos.y as f32,
                 entity_manager,
             )?;
+            let entity = handle.entity();
             entity.set_position(entity_data.pos.x as f64, entity_data.pos.y as f64, None)?;
             if entity_data.is_charmed {
-                if entity_manager.has_tag(const { CachedTag::from_tag("boss_centipede") }) {
+                if handle.has_tag(const { CachedTag::from_tag("boss_centipede") }) {
                     self.enable_later.push(entity);
-                } else if entity_manager.has_tag(const { CachedTag::from_tag("pitcheck_b") }) {
-                    entity_manager
+                } else if handle.has_tag(const { CachedTag::from_tag("pitcheck_b") }) {
+                    handle
                         .entity()
                         .set_components_with_tag_enabled("disabled".into(), true)?;
-                } else if let Some(var) =
-                    entity_manager.get_var(const { VarName::from_str("active") })
-                {
+                } else if let Some(var) = handle.get_var(const { VarName::from_str("active") }) {
                     var.set_value_int(1)?;
-                    entity_manager.set_components_with_tag_enabled(
+                    handle.set_components_with_tag_enabled(
                         const { ComponentTag::from_str("activate") },
                         true,
                     )?
@@ -1036,7 +1021,7 @@ impl LocalDiffModel {
                 }
             }
             for (name, s, i, f, b) in &entity_data.synced_var {
-                let v = entity_manager.get_var_or_default_unknown(name)?;
+                let v = handle.get_var_or_default_unknown(name)?;
                 v.set_value_string(s.into())?;
                 v.set_value_int(*i)?;
                 v.set_value_float(*f)?;
@@ -1046,11 +1031,11 @@ impl LocalDiffModel {
                 self.phys_later.push((entity, entity_data.phys));
             }
 
-            mom(entity_manager, entity_data.counter, None)?;
-            sun(entity_manager, entity_data.counter)?;
+            mom(&mut handle, entity_data.counter, None)?;
+            sun(&mut handle, entity_data.counter)?;
             if entity_data.hp != -1.0
-                && let Some(damage) = entity_manager
-                    .try_get_first_component::<DamageModelComponent>(ComponentTag::None)
+                && let Some(damage) =
+                    handle.try_get_first_component::<DamageModelComponent>(ComponentTag::None)
             {
                 if entity_data.hp > damage.max_hp_cap()? as f32 {
                     damage.set_max_hp_cap(entity_data.hp as f64)?;
@@ -1061,21 +1046,21 @@ impl LocalDiffModel {
                 damage.set_hp(entity_data.hp as f64)?;
             }
             if !entity_data.drops_gold {
-                let n = entity_manager
+                let n = handle
                     .iter_all_components_of_type::<LuaComponent>(ComponentTag::None)
                     .find(|lua| {
                         lua.script_death().ok() == Some("data/scripts/items/drop_money.lua".into())
                     });
                 if let Some(lua) = n {
-                    entity_manager.remove_component(lua)?
+                    handle.remove_component(lua)?
                 }
-            } else if entity_manager.has_tag(const { CachedTag::from_tag("boss_dragon") }) {
-                let lua = entity_manager.add_component::<LuaComponent>()?;
+            } else if handle.has_tag(const { CachedTag::from_tag("boss_dragon") }) {
+                let lua = handle.add_component::<LuaComponent>()?;
                 lua.set_script_death("data/scripts/animals/boss_dragon_death.lua".into())?;
                 lua.set_execute_every_n_frame(-1)?;
             }
             if let Some(wand) = entity_data.wand {
-                give_wand(entity, &wand, None, false, None, entity_manager)?;
+                give_wand(&mut handle, &wand, None, false, None)?;
             }
             let lid = self.track_entity(entity, entity_data.gid, entity_manager)?;
             self.dont_upload.insert(lid);
@@ -1428,8 +1413,7 @@ impl LocalDiffModel {
         if let Ok(entity) = self.tracker.entity_by_lid(lid) {
             if info.current.as_ref().unwrap().kind == EntityKind::Item {
                 self.tracker.pending_localize.push((lid, source));
-                entity_manager.set_current_entity(entity)?;
-                safe_entitykill(entity_manager);
+                safe_entitykill(entity_manager.handle(entity)?);
                 // "Untrack" entity
                 self.tracker.tracked.remove_by_left(&lid);
                 if let Some(gid) = self.entity_entries.remove(&lid).map(|e| e.gid) {
@@ -1533,8 +1517,7 @@ impl RemoteDiffModel {
                     if let Some((_, entity)) = self.tracked.remove_by_left(&lid)
                         && peer_id != my_peer_id()
                     {
-                        entity_manager.set_current_entity(entity)?;
-                        safe_entitykill(entity_manager);
+                        safe_entitykill(entity_manager.handle(entity)?);
                     }
                     self.entity_infos.remove(&lid);
                     ent_data = empty_data;
@@ -1577,16 +1560,16 @@ impl RemoteDiffModel {
         &self,
         ctx: &mut ModuleCtx,
         entity_info: &EntityInfo,
-        entity: EntityID,
         lid: &Lid,
-        entity_manager: &mut EntityManager,
+        handle: &mut EntityHandle,
         sprite_animations: &mut SpriteAnimations,
     ) -> eyre::Result<Option<Lid>> {
+        let entity = handle.entity();
         if entity_info.kind == EntityKind::Item && item_in_my_inventory(entity)?
             || item_in_entity_inventory(entity)?
         {
-            entity_manager.remove_tag(const { CachedTag::from_tag(DES_TAG) })?;
-            with_entity_scripts(entity_manager, |luac| {
+            handle.remove_tag(const { CachedTag::from_tag(DES_TAG) })?;
+            with_entity_scripts(handle, |luac| {
                 luac.set_script_throw_item(
                     "mods/quant.ew/files/system/entity_sync_helper/item_notify.lua".into(),
                 )
@@ -1601,28 +1584,17 @@ impl RemoteDiffModel {
             return Ok(Some(*lid));
         }
         for (name, s, i, f, b) in &entity_info.synced_var {
-            let v = entity_manager.get_var_or_default_unknown(name)?;
+            let v = handle.get_var_or_default_unknown(name)?;
             v.set_value_string(s.into())?;
             v.set_value_int(*i)?;
             v.set_value_float(*f)?;
             v.set_value_bool(*b)?;
         }
-        mom(
-            entity_manager,
-            entity_info.counter,
-            Some(entity_info.cost as i32),
-        )?;
-        sun(entity_manager, entity_info.counter)?;
+        mom(handle, entity_info.counter, Some(entity_info.cost as i32))?;
+        sun(handle, entity_info.counter)?;
 
         if let Some((gid, seri, _)) = &entity_info.wand {
-            give_wand(
-                entity,
-                seri,
-                *gid,
-                true,
-                Some(entity_info.wand_rotation),
-                entity_manager,
-            )?;
+            give_wand(handle, seri, *gid, true, Some(entity_info.wand_rotation))?;
         } else if let Some(inv) = entity
             .children(None)
             .find(|e| e.name().unwrap_or("".into()) == "inventory_quick")
@@ -1630,25 +1602,23 @@ impl RemoteDiffModel {
             inv.children(None).for_each(|e| e.kill())
         }
         if entity_info.is_enabled {
-            if entity_manager
+            if handle
                 .get_var(const { VarName::from_str("ew_has_started") })
                 .is_none()
             {
-                entity_manager.set_components_with_tag_enabled(
+                handle.set_components_with_tag_enabled(
                     const { ComponentTag::from_str("disabled_at_start") },
                     true,
                 )?;
-                entity_manager.set_components_with_tag_enabled(
+                handle.set_components_with_tag_enabled(
                     const { ComponentTag::from_str("enabled_at_start") },
                     false,
                 )?;
-                entity_manager.add_tag(const { CachedTag::from_tag("boss_centipede_active") })?;
+                handle.add_tag(const { CachedTag::from_tag("boss_centipede_active") })?;
                 let mut to_remove = Vec::new();
-                for lua in entity_manager
-                    .iter_all_components_of_type_including_disabled::<LuaComponent>(
-                        ComponentTag::None,
-                    )
-                {
+                for lua in handle.iter_all_components_of_type_including_disabled::<LuaComponent>(
+                    ComponentTag::None,
+                ) {
                     if [
                         "data/entities/animals/boss_centipede/boss_centipede_before_fight.lua",
                         "data/entities/animals/boss_centipede/boss_centipede_update.lua",
@@ -1659,29 +1629,28 @@ impl RemoteDiffModel {
                     }
                 }
                 for lua in to_remove {
-                    entity_manager.remove_component(lua)?;
+                    handle.remove_component(lua)?;
                 }
-                let immortal = entity_manager.add_component::<LuaComponent>()?;
+                let immortal = handle.add_component::<LuaComponent>()?;
                 immortal.add_tag("ew_immortal")?;
                 immortal.set_script_damage_about_to_be_received(
                     "mods/quant.ew/files/system/entity_sync_helper/immortal.lua".into(),
                 )?;
-                entity_manager
+                handle
                     .add_component_with_var_name(const { VarName::from_str("ew_has_started") })?;
                 entity
                     .children(Some("protection".into()))
                     .for_each(|ent| ent.kill());
-            } else if let Some(var) = entity_manager.get_var(const { VarName::from_str("active") })
-            {
+            } else if let Some(var) = handle.get_var(const { VarName::from_str("active") }) {
                 var.set_value_int(1)?;
-                entity_manager.set_components_with_tag_enabled(
+                handle.set_components_with_tag_enabled(
                     const { ComponentTag::from_str("activate") },
                     true,
                 )?
             }
-        } else if let Some(var) = entity_manager.get_var(const { VarName::from_str("active") }) {
+        } else if let Some(var) = handle.get_var(const { VarName::from_str("active") }) {
             var.set_value_int(0)?;
-            entity_manager.set_components_with_tag_enabled(
+            handle.set_components_with_tag_enabled(
                 const { ComponentTag::from_str("activate") },
                 false,
             )?
@@ -1695,13 +1664,13 @@ impl RemoteDiffModel {
                 limb.set_end_position((*x, *y))?;
             }
             if let Ok(limb) = ent.get_first_component::<IKLimbWalkerComponent>(None) {
-                entity_manager.remove_component(limb)?
+                handle.remove_component(limb)?
             };
             if let Ok(limb) = ent.get_first_component::<IKLimbAttackerComponent>(None) {
-                entity_manager.remove_component(limb)?
+                handle.remove_component(limb)?
             };
             if let Ok(limb) = ent.get_first_component::<IKLimbsAnimatorComponent>(None) {
-                entity_manager.remove_component(limb)?
+                handle.remove_component(limb)?
             };
         }
         let m = *ctx.fps_by_player.get(&self.peer_id).unwrap_or(&60) as f32
@@ -1709,10 +1678,10 @@ impl RemoteDiffModel {
         let (vx, vy) = (entity_info.vx * m, entity_info.vy * m);
         if entity_info.phys.is_empty()
             || (entity_info.is_enabled
-                && entity_manager.has_tag(const { CachedTag::from_tag("boss_centipede") }))
+                && handle.has_tag(const { CachedTag::from_tag("boss_centipede") }))
         {
             let should_send_position = if let Some(com) =
-                entity_manager.try_get_first_component::<ItemComponent>(ComponentTag::None)
+                handle.try_get_first_component::<ItemComponent>(ComponentTag::None)
             {
                 !com.play_hover_animation()?
             } else {
@@ -1720,7 +1689,7 @@ impl RemoteDiffModel {
             };
 
             let should_send_rotation = if let Some(com) =
-                entity_manager.try_get_first_component::<ItemComponent>(ComponentTag::None)
+                handle.try_get_first_component::<ItemComponent>(ComponentTag::None)
             {
                 !com.play_spinning_animation()? || com.play_hover_animation()?
             } else {
@@ -1739,25 +1708,25 @@ impl RemoteDiffModel {
                 entity.set_position(x, y, Some(entity_info.r as f64))?;
             }
             if let Some(worm) =
-                entity_manager.try_get_first_component::<BossDragonComponent>(ComponentTag::None)
+                handle.try_get_first_component::<BossDragonComponent>(ComponentTag::None)
             {
                 worm.set_m_target_vec((vx, vy))?;
             } else if let Some(worm) =
-                entity_manager.try_get_first_component::<WormComponent>(ComponentTag::None)
+                handle.try_get_first_component::<WormComponent>(ComponentTag::None)
             {
                 worm.set_m_target_vec((vx, vy))?;
             } else if let Some(vel) =
-                entity_manager.try_get_first_component::<CharacterDataComponent>(ComponentTag::None)
+                handle.try_get_first_component::<CharacterDataComponent>(ComponentTag::None)
             {
                 vel.set_m_velocity((vx, vy))?;
             } else if let Some(vel) =
-                entity_manager.try_get_first_component::<VelocityComponent>(ComponentTag::None)
+                handle.try_get_first_component::<VelocityComponent>(ComponentTag::None)
             {
                 vel.set_m_velocity((vx, vy))?;
             }
         }
         if let Some(damage) =
-            entity_manager.try_get_first_component::<DamageModelComponent>(ComponentTag::None)
+            handle.try_get_first_component::<DamageModelComponent>(ComponentTag::None)
         {
             if entity_info.hp > damage.max_hp()? as f32 {
                 damage.set_max_hp(entity_info.hp as f64)?
@@ -1799,7 +1768,7 @@ impl RemoteDiffModel {
             }
         }
 
-        if !entity_info.phys.is_empty() && entity_manager.check_all_phys_init()? {
+        if !entity_info.phys.is_empty() && handle.check_all_phys_init()? {
             let phys_bodies = entity.get_physics_body_ids().unwrap_or_default();
             for (p, physics_body_id) in entity_info.phys.iter().zip(phys_bodies.iter()) {
                 let Some(p) = p else {
@@ -1817,12 +1786,11 @@ impl RemoteDiffModel {
             }
         }
 
-        if let Some(cost) =
-            entity_manager.try_get_first_component::<ItemCostComponent>(ComponentTag::None)
+        if let Some(cost) = handle.try_get_first_component::<ItemCostComponent>(ComponentTag::None)
         {
             cost.set_cost(entity_info.cost)?;
             if entity_info.cost == 0 {
-                entity_manager.set_components_with_tag_enabled(
+                handle.set_components_with_tag_enabled(
                     const { ComponentTag::from_str("shop_cost") },
                     false,
                 )?;
@@ -1831,21 +1799,21 @@ impl RemoteDiffModel {
 
         entity.set_game_effects(&entity_info.game_effects)?;
 
-        if entity_manager
+        if handle
             .get_var(const { VarName::from_str("rolling") })
             .is_some()
         {
-            let var = entity_manager.get_var_or_default(const { VarName::from_str("ew_rng") })?;
+            let var = handle.get_var_or_default(const { VarName::from_str("ew_rng") })?;
             let bytes = entity_info.current_stains.to_le_bytes();
             let is_rolling = bytes[0];
             let bytes: [u8; 4] = [bytes[4], bytes[5], bytes[6], bytes[7]];
             let rng = i32::from_le_bytes(bytes);
             var.set_value_int(rng)?;
-            let var = entity_manager.get_var_or_default(const { VarName::from_str("rolling") })?;
+            let var = handle.get_var_or_default(const { VarName::from_str("rolling") })?;
             if is_rolling == 1 {
                 if var.value_int()? == 0 {
                     var.set_value_int(4)?;
-                    entity_manager
+                    handle
                         .iter_all_components_of_type::<SpriteComponent>(ComponentTag::None)
                         .for_each(|s| {
                             let _ = s.set_rect_animation("roll".into());
@@ -1860,16 +1828,15 @@ impl RemoteDiffModel {
                 var.set_value_int(0)?;
             }
         } else {
-            entity_manager.set_current_stains(entity_info.current_stains)?;
+            handle.set_current_stains(entity_info.current_stains)?;
         }
-        if let Some(ai) = entity_manager
+        if let Some(ai) = handle
             .try_get_first_component_including_disabled::<AnimalAIComponent>(ComponentTag::None)
         {
             ai.set_ai_state(entity_info.ai_state)?;
             ai.set_m_ranged_attack_current_aim_angle(entity_info.ai_rotation)?;
         } else {
-            let sprites =
-                entity_manager.iter_all_components_of_type::<SpriteComponent>(ComponentTag::None);
+            let sprites = handle.iter_all_components_of_type::<SpriteComponent>(ComponentTag::None);
             for (sprite, animation) in sprites
                 .filter(|sprite| {
                     sprite
@@ -1898,13 +1865,12 @@ impl RemoteDiffModel {
                 }
             }
         }
-        let laser =
-            entity_manager.try_get_first_component::<LaserEmitterComponent>(ComponentTag::None);
+        let laser = handle.try_get_first_component::<LaserEmitterComponent>(ComponentTag::None);
         if entity_info.laser != Target::None {
             let laser = if let Some(laser) = laser {
                 laser
             } else {
-                let laser = entity_manager.add_component::<LaserEmitterComponent>()?;
+                let laser = handle.add_component::<LaserEmitterComponent>()?;
                 laser.object_set_value::<i32>("laser", "max_cell_durability_to_destroy", 0)?;
                 laser.object_set_value::<i32>("laser", "damage_to_cells", 0)?;
                 laser.object_set_value::<i32>("laser", "max_length", 1024)?;
@@ -1956,27 +1922,24 @@ impl RemoteDiffModel {
         for (i, (lid, entity_info)) in self.entity_infos.iter().enumerate() {
             match self.tracked.get_by_left(lid) {
                 Some(entity) if entity.is_alive() => {
-                    entity_manager.set_current_entity(*entity)?;
+                    let mut handle = entity_manager.handle(*entity)?;
                     if tmr.elapsed().as_micros() > 5000 || start > i {
                         if end.is_none() && start <= i {
                             end = Some(i);
                         }
                         if entity_info.phys.is_empty()
                             || (entity_info.is_enabled
-                                && entity_manager
-                                    .has_tag(const { CachedTag::from_tag("boss_centipede") }))
+                                && handle.has_tag(const { CachedTag::from_tag("boss_centipede") }))
                         {
                             let should_send_position = if let Some(com) =
-                                entity_manager
-                                    .try_get_first_component::<ItemComponent>(ComponentTag::None)
+                                handle.try_get_first_component::<ItemComponent>(ComponentTag::None)
                             {
                                 !com.play_hover_animation()?
                             } else {
                                 true
                             };
                             let should_send_rotation = if let Some(com) =
-                                entity_manager
-                                    .try_get_first_component::<ItemComponent>(ComponentTag::None)
+                                handle.try_get_first_component::<ItemComponent>(ComponentTag::None)
                             {
                                 !com.play_spinning_animation()? || com.play_hover_animation()?
                             } else {
@@ -2000,14 +1963,7 @@ impl RemoteDiffModel {
                             }
                         }
                     } else {
-                        match self.inner(
-                            ctx,
-                            entity_info,
-                            *entity,
-                            lid,
-                            entity_manager,
-                            sprite_animations,
-                        ) {
+                        match self.inner(ctx, entity_info, lid, &mut handle, sprite_animations) {
                             Ok(Some(lid)) => to_remove.push(lid),
                             Err(s) => print_error(s)?,
                             _ => {}
@@ -2031,7 +1987,8 @@ impl RemoteDiffModel {
                                 entity_info.x,
                                 entity_info.y,
                                 entity_manager,
-                            )?;
+                            )?
+                            .entity();
                             init_remote_entity(
                                 entity,
                                 Some(*lid),
@@ -2065,9 +2022,9 @@ impl RemoteDiffModel {
             let Some(entity) = self.tracked.get_by_left(&lid).copied() else {
                 continue;
             };
-            entity_manager.set_current_entity(entity)?;
-            if let Some(explosion) = entity_manager
-                .try_get_first_component::<ExplodeOnDamageComponent>(ComponentTag::None)
+            let handle = entity_manager.handle(entity)?;
+            if let Some(explosion) =
+                handle.try_get_first_component::<ExplodeOnDamageComponent>(ComponentTag::None)
             {
                 explosion.set_explode_on_death_percent(1.0)?;
             }
@@ -2078,7 +2035,7 @@ impl RemoteDiffModel {
                 inv.children(None).for_each(|e| e.kill())
             }
             if let Some(damage) =
-                entity_manager.try_get_first_component::<DamageModelComponent>(ComponentTag::None)
+                handle.try_get_first_component::<DamageModelComponent>(ComponentTag::None)
             {
                 entity_manager.remove_ent(&entity);
                 entity
@@ -2112,8 +2069,7 @@ impl RemoteDiffModel {
         for lid in self.pending_remove.drain(..) {
             self.entity_infos.remove(&lid);
             if let Some((_, entity)) = self.tracked.remove_by_left(&lid) {
-                entity_manager.set_current_entity(entity)?;
-                safe_entitykill(entity_manager);
+                safe_entitykill(entity_manager.handle(entity)?);
             }
         }
         Ok(())
@@ -2172,25 +2128,23 @@ pub fn init_remote_entity(
         entity_manager.remove_ent(&entity);
         return Ok(());
     }
-    entity_manager.set_current_entity(entity)?;
-    entity_manager.remove_all_components_of_type::<CameraBoundComponent>(ComponentTag::None)?;
-    entity_manager
-        .remove_all_components_of_type::<StreamingKeepAliveComponent>(ComponentTag::None)?;
-    entity_manager
-        .remove_all_components_of_type::<CharacterPlatformingComponent>(ComponentTag::None)?;
-    entity_manager.remove_all_components_of_type::<PhysicsAIComponent>(ComponentTag::None)?;
-    entity_manager.remove_all_components_of_type::<AdvancedFishAIComponent>(ComponentTag::None)?;
-    entity_manager.remove_all_components_of_type::<IKLimbsAnimatorComponent>(ComponentTag::None)?;
-    entity_manager.remove_all_components_of_type::<LifetimeComponent>(ComponentTag::None)?;
+    let mut handle = entity_manager.handle(entity)?;
+    handle.remove_all_components_of_type::<CameraBoundComponent>(ComponentTag::None)?;
+    handle.remove_all_components_of_type::<StreamingKeepAliveComponent>(ComponentTag::None)?;
+    handle.remove_all_components_of_type::<CharacterPlatformingComponent>(ComponentTag::None)?;
+    handle.remove_all_components_of_type::<PhysicsAIComponent>(ComponentTag::None)?;
+    handle.remove_all_components_of_type::<AdvancedFishAIComponent>(ComponentTag::None)?;
+    handle.remove_all_components_of_type::<IKLimbsAnimatorComponent>(ComponentTag::None)?;
+    handle.remove_all_components_of_type::<LifetimeComponent>(ComponentTag::None)?;
     let mut any = false;
-    for ai in entity_manager
+    for ai in handle
         .iter_all_components_of_type_including_disabled::<AIAttackComponent>(ComponentTag::None)
     {
         any = any || ai.attack_ranged_aim_rotation_enabled()?;
         ai.set_attack_ranged_entity_count_max(0)?;
         ai.set_attack_ranged_entity_count_min(0)?;
     }
-    for ai in entity_manager
+    for ai in handle
         .iter_all_components_of_type_including_disabled::<AnimalAIComponent>(ComponentTag::None)
     {
         any = any || ai.attack_ranged_aim_rotation_enabled()?;
@@ -2204,58 +2158,52 @@ pub fn init_remote_entity(
         ai.set_keep_state_alive_when_enabled(true)?;
     }
     if !any {
-        entity_manager.remove_all_components_of_type::<AnimalAIComponent>(ComponentTag::None)?;
-        entity_manager.remove_all_components_of_type::<AIAttackComponent>(ComponentTag::None)?;
-        for sprite in entity_manager.iter_all_components_of_type::<SpriteComponent>(
+        handle.remove_all_components_of_type::<AnimalAIComponent>(ComponentTag::None)?;
+        handle.remove_all_components_of_type::<AIAttackComponent>(ComponentTag::None)?;
+        for sprite in handle.iter_all_components_of_type::<SpriteComponent>(
             const { ComponentTag::from_str("character") },
         ) {
             sprite.remove_tag("character")?;
             sprite.set_has_special_scale(true)?;
         }
     }
-    if let Some(w) = entity_manager
-        .try_get_first_component_including_disabled::<WormComponent>(ComponentTag::None)
+    if let Some(w) =
+        handle.try_get_first_component_including_disabled::<WormComponent>(ComponentTag::None)
     {
         w.set_bite_damage(0.0)?;
     }
-    if let Some(w) = entity_manager
-        .try_get_first_component_including_disabled::<BossDragonComponent>(ComponentTag::None)
+    if let Some(w) =
+        handle.try_get_first_component_including_disabled::<BossDragonComponent>(ComponentTag::None)
     {
         w.set_bite_damage(0.0)?;
     }
-    entity_manager.add_tag(const { CachedTag::from_tag(DES_TAG) })?;
-    entity_manager.add_tag(const { CachedTag::from_tag("polymorphable_NOT") })?;
+    handle.add_tag(const { CachedTag::from_tag(DES_TAG) })?;
+    handle.add_tag(const { CachedTag::from_tag("polymorphable_NOT") })?;
     if lid.is_some()
         && let Some(damage) =
-            entity_manager.try_get_first_component::<DamageModelComponent>(ComponentTag::None)
+            handle.try_get_first_component::<DamageModelComponent>(ComponentTag::None)
     {
         damage.set_wait_for_kill_flag_on_death(true)?;
         damage.set_physics_objects_damage(false)?;
     }
 
-    for pb2 in
-        entity_manager.iter_all_components_of_type::<PhysicsBody2Component>(ComponentTag::None)
-    {
+    for pb2 in handle.iter_all_components_of_type::<PhysicsBody2Component>(ComponentTag::None) {
         pb2.set_destroy_body_if_entity_destroyed(true)?;
     }
 
-    for expl in
-        entity_manager.iter_all_components_of_type::<ExplodeOnDamageComponent>(ComponentTag::None)
-    {
+    for expl in handle.iter_all_components_of_type::<ExplodeOnDamageComponent>(ComponentTag::None) {
         expl.set_explode_on_damage_percent(0.0)?;
         expl.set_explode_on_death_percent(0.0)?;
         expl.set_physics_body_modified_death_probability(0.0)?;
     }
 
-    if let Some(itemc) =
-        entity_manager.try_get_first_component::<ItemCostComponent>(ComponentTag::None)
-    {
+    if let Some(itemc) = handle.try_get_first_component::<ItemCostComponent>(ComponentTag::None) {
         itemc.set_stealable(false)?;
     }
 
     let mut to_remove = Vec::new();
-    for lua in entity_manager
-        .iter_all_components_of_type_including_disabled::<LuaComponent>(ComponentTag::None)
+    for lua in
+        handle.iter_all_components_of_type_including_disabled::<LuaComponent>(ComponentTag::None)
     {
         if (!drops_gold
             && lua.script_death().ok() == Some("data/scripts/items/drop_money.lua".into()))
@@ -2304,43 +2252,43 @@ pub fn init_remote_entity(
         }
     }
     for lua in to_remove {
-        entity_manager.remove_component(lua)?;
+        handle.remove_component(lua)?;
     }
-    let immortal = entity_manager.add_component::<LuaComponent>()?;
+    let immortal = handle.add_component::<LuaComponent>()?;
     immortal.add_tag("ew_immortal")?;
     immortal.set_script_damage_about_to_be_received(
         "mods/quant.ew/files/system/entity_sync_helper/immortal.lua".into(),
     )?;
-    if let Some(var) = entity_manager.get_var(const { VarName::from_str("ghost_id") })
+    if let Some(var) = handle.get_var(const { VarName::from_str("ghost_id") })
         && let Ok(ent) = EntityID::try_from(var.value_int()? as isize)
     {
         ent.kill()
     }
-    if entity_manager.has_tag(const { CachedTag::from_tag("boss_dragon") }) && drops_gold {
-        let lua = entity_manager.add_component::<LuaComponent>()?;
+    if handle.has_tag(const { CachedTag::from_tag("boss_dragon") }) && drops_gold {
+        let lua = handle.add_component::<LuaComponent>()?;
         lua.set_script_death("data/scripts/animals/boss_dragon_death.lua".into())?;
         lua.set_execute_every_n_frame(-1)?;
     }
-    if let Some(life) = entity_manager
-        .try_get_first_component_including_disabled::<LifetimeComponent>(ComponentTag::None)
+    if let Some(life) =
+        handle.try_get_first_component_including_disabled::<LifetimeComponent>(ComponentTag::None)
     {
         life.set_lifetime(i32::MAX)?;
     }
-    if let Some(pickup) = entity_manager
+    if let Some(pickup) = handle
         .try_get_first_component_including_disabled::<ItemPickUpperComponent>(ComponentTag::None)
     {
         pickup.set_drop_items_on_death(false)?;
         pickup.set_only_pick_this_entity(Some(EntityID(NonZero::new(1).unwrap())))?;
     }
 
-    if let Some(ghost) = entity_manager
-        .try_get_first_component_including_disabled::<GhostComponent>(ComponentTag::None)
+    if let Some(ghost) =
+        handle.try_get_first_component_including_disabled::<GhostComponent>(ComponentTag::None)
     {
         ghost.set_die_if_no_home(false)?;
     }
 
-    if entity_manager.has_tag(const { CachedTag::from_tag("egg_item") })
-        && let Some(explosion) = entity_manager
+    if handle.has_tag(const { CachedTag::from_tag("egg_item") })
+        && let Some(explosion) = handle
             .try_get_first_component_including_disabled::<ExplodeOnDamageComponent>(
                 ComponentTag::None,
             )
@@ -2352,16 +2300,15 @@ pub fn init_remote_entity(
         )?
     }
 
-    if let Some(var) = entity_manager.get_var(const { VarName::from_str("ew_gid_lid") }) {
-        entity_manager.remove_component(var)?;
+    if let Some(var) = handle.get_var(const { VarName::from_str("ew_gid_lid") }) {
+        handle.remove_component(var)?;
     }
-    if let Some(var) = entity_manager.get_var(const { VarName::from_str("throw_time") }) {
-        var.set_value_int(entity_manager.frame_num() - 4)?;
+    if let Some(var) = handle.get_var(const { VarName::from_str("throw_time") }) {
+        var.set_value_int(handle.frame_num() - 4)?;
     }
 
     if let Some(lid) = lid {
-        let var = entity_manager
-            .add_component_with_var_name(const { VarName::from_str("ew_gid_lid") })?;
+        let var = handle.add_component_with_var_name(const { VarName::from_str("ew_gid_lid") })?;
         if let Some(gid) = gid {
             var.set_value_string(gid.0.to_string().into())?;
         }
@@ -2369,10 +2316,10 @@ pub fn init_remote_entity(
         var.set_value_bool(false)?;
     }
 
-    if entity_manager
+    if handle
         .try_get_first_component_including_disabled::<PhysicsBodyComponent>(ComponentTag::None)
         .is_none()
-        && entity_manager
+        && handle
             .try_get_first_component_including_disabled::<PhysicsBody2Component>(ComponentTag::None)
             .is_none()
     {
@@ -2397,12 +2344,8 @@ pub fn init_remote_entity(
 /// by itself when the item is dropped from an inventory. `ew_no_ground` marks
 /// items we disabled it on, so one that was already disabled - like a wand
 /// placed by EZWand - is left alone once the world shows up.
-fn hold_over_ungenerated_world(
-    entity_manager: &mut EntityManager,
-    x: f64,
-    y: f64,
-) -> eyre::Result<()> {
-    let held = entity_manager.get_var(const { VarName::from_str("ew_no_ground") });
+fn hold_over_ungenerated_world(handle: &mut EntityHandle, x: f64, y: f64) -> eyre::Result<()> {
+    let held = handle.get_var(const { VarName::from_str("ew_no_ground") });
     let has_world = does_world_exist_at(
         (x - 4.0) as i32,
         (y - 4.0) as i32,
@@ -2412,21 +2355,21 @@ fn hold_over_ungenerated_world(
     match (has_world, held) {
         (false, None) => {
             if let Some(physics) =
-                entity_manager.try_get_first_component::<SimplePhysicsComponent>(ComponentTag::None)
+                handle.try_get_first_component::<SimplePhysicsComponent>(ComponentTag::None)
             {
-                entity_manager.set_component_enabled(physics, false)?;
-                entity_manager.get_var_or_default(const { VarName::from_str("ew_no_ground") })?;
+                handle.set_component_enabled(physics, false)?;
+                handle.get_var_or_default(const { VarName::from_str("ew_no_ground") })?;
             }
         }
         (true, Some(var)) => {
-            if let Some(physics) = entity_manager
+            if let Some(physics) = handle
                 .try_get_first_component_including_disabled::<SimplePhysicsComponent>(
                     ComponentTag::None,
                 )
             {
-                entity_manager.set_component_enabled(physics, true)?;
+                handle.set_component_enabled(physics, true)?;
             }
-            entity_manager.remove_component(var)?;
+            handle.remove_component(var)?;
         }
         _ => {}
     }
@@ -2460,20 +2403,18 @@ fn not_in_player_inventory(entity: EntityID) -> Result<bool, eyre::Error> {
         .unwrap_or(true))
 }
 
-fn spawn_entity_by_data(
+fn spawn_entity_by_data<'a>(
     entity_data: &EntitySpawnInfo,
     x: f32,
     y: f32,
-    entity_manager: &mut EntityManager,
-) -> eyre::Result<EntityID> {
+    entity_manager: &'a mut EntityManager,
+) -> eyre::Result<EntityHandle<'a>> {
     match entity_data {
         EntitySpawnInfo::Filename(filename) => {
             let ent = EntityID::load(filename, Some(x as f64), Some(y as f64))?;
-            entity_manager.set_current_entity(ent)?;
+            let mut handle = entity_manager.handle(ent)?;
             let mut to_remove = Vec::new();
-            for lua in
-                entity_manager.iter_all_components_of_type::<LuaComponent>(ComponentTag::None)
-            {
+            for lua in handle.iter_all_components_of_type::<LuaComponent>(ComponentTag::None) {
                 if ["data/scripts/props/suspended_container_physics_objects.lua"]
                     .contains(&&*lua.script_source_file()?)
                 {
@@ -2481,21 +2422,16 @@ fn spawn_entity_by_data(
                 }
             }
             for lua in to_remove {
-                entity_manager.remove_component(lua)?;
+                handle.remove_component(lua)?;
             }
-            Ok(ent)
+            Ok(handle)
         }
         EntitySpawnInfo::Serialized {
             //serialized_at: _,
             data,
         } => {
             let ent = deserialize_entity(data, x, y)?;
-            // Callers keep talking to the entity through the manager afterwards.
-            // Without this the whole post-spawn setup - hp, synced vars, gold
-            // drops - lands on whichever entity happened to be current.
-            // fix developed by mirashii
-            entity_manager.set_current_entity(ent)?;
-            Ok(ent)
+            entity_manager.handle(ent)
         }
     }
 }
@@ -2516,17 +2452,17 @@ fn classify_entity(entity: EntityID) -> eyre::Result<EntityKind> {
 }
 
 fn with_entity_scripts<T>(
-    entity: &mut EntityManager,
+    handle: &mut EntityHandle,
     f: impl FnOnce(LuaComponent) -> eyre::Result<T>,
 ) -> eyre::Result<T> {
     let component = if let Some(c) =
-        entity.try_get_first_component(const { ComponentTag::from_str(DES_SCRIPTS_TAG) })
+        handle.try_get_first_component(const { ComponentTag::from_str(DES_SCRIPTS_TAG) })
     {
         c
     } else {
-        let component = entity.add_component::<LuaComponent>()?;
-        // Through the manager, so the lookup above can find it next time.
-        entity.add_component_tag(component, const { ComponentTag::from_str(DES_SCRIPTS_TAG) })?;
+        let component = handle.add_component::<LuaComponent>()?;
+        // Through the handle, so the lookup above can find it next time.
+        handle.add_component_tag(component, const { ComponentTag::from_str(DES_SCRIPTS_TAG) })?;
         component.add_tag("enabled_in_inventory")?;
         component.add_tag("enabled_in_world")?;
         component.add_tag("enabled_in_hand")?;
@@ -2556,57 +2492,57 @@ fn with_entity_scripts_no_mgr<T>(
 }
 
 /// If it's a wand, it might be in a pickup screen currently, and deleting it will crash the game.
-fn _safe_wandkill(entity: &mut EntityManager) -> eyre::Result<()> {
+fn _safe_wandkill(handle: &mut EntityHandle) -> eyre::Result<()> {
     //TODO ent mgr
-    let lc = entity.add_component::<LuaComponent>()?;
+    let lc = handle.add_component::<LuaComponent>()?;
     lc.set_script_source_file(
         "mods/quant.ew/files/system/entity_sync_helper/scripts/killself.lua".into(),
     )?;
-    entity.set_component_enabled(lc, true)?;
+    handle.set_component_enabled(lc, true)?;
     lc.add_tag("enabled_in_inventory")?;
     lc.add_tag("enabled_in_world")?;
     lc.add_tag("enabled_in_hand")?;
     lc.set_execute_on_added(false)?;
-    lc.set_m_next_execution_time(entity.frame_num() + 1)?;
+    lc.set_m_next_execution_time(handle.frame_num() + 1)?;
     Ok(())
 }
 
-fn safe_entitykill(entity: &mut EntityManager) {
-    let _ = entity.remove_all_components_of_type::<AudioComponent>(ComponentTag::None);
+fn safe_entitykill(mut handle: EntityHandle) {
+    let _ = handle.remove_all_components_of_type::<AudioComponent>(ComponentTag::None);
     let is_wand =
-        entity.try_get_first_component_including_disabled::<AbilityComponent>(ComponentTag::None);
+        handle.try_get_first_component_including_disabled::<AbilityComponent>(ComponentTag::None);
     if is_wand
         .map(|b| b.use_gun_script().unwrap_or(false))
         .unwrap_or(false)
     {
-        let _ = _safe_wandkill(entity);
+        let _ = _safe_wandkill(&mut handle);
     } else {
-        if let Some(inv) = entity
+        if let Some(inv) = handle
             .entity()
             .children(None)
             .find(|e| e.name().unwrap_or("".into()) == "inventory_quick")
         {
             inv.children(None).for_each(|e| e.kill())
         }
-        entity.entity().kill();
+        handle.entity().kill();
     }
-    entity.remove_current();
+    handle.forget();
 }
 
 fn give_wand(
-    entity: EntityID,
+    handle: &mut EntityHandle,
     seri: &[u8],
     gid: Option<Gid>,
     delete: bool,
     r: Option<f32>,
-    entity_manager: &mut EntityManager,
 ) -> eyre::Result<()> {
-    let inv = if let Some(inv) = entity_manager
-        .try_get_first_component_including_disabled::<Inventory2Component>(ComponentTag::None)
+    let entity = handle.entity();
+    let inv = if let Some(inv) =
+        handle.try_get_first_component_including_disabled::<Inventory2Component>(ComponentTag::None)
     {
         inv
     } else {
-        entity_manager.add_component::<Inventory2Component>()?
+        handle.add_component::<Inventory2Component>()?
     };
     let mut stop = false;
     if let Some(wand) = inv.m_actual_active_item()? {
@@ -2616,23 +2552,23 @@ fn give_wand(
         {
             if gid != Some(Gid(tgid)) {
                 if r.is_some() {
-                    entity_manager.set_component_enabled(inv, true)?;
+                    handle.set_component_enabled(inv, true)?;
                 }
                 wand.kill()
             } else {
                 if r.is_some() {
-                    entity_manager.set_component_enabled(inv, false)?;
+                    handle.set_component_enabled(inv, false)?;
                 }
                 stop = true
             }
         } else if wand.get_var("ew_spawned_wand").is_some() {
             if r.is_some() {
-                entity_manager.set_component_enabled(inv, false)?;
+                handle.set_component_enabled(inv, false)?;
             }
             stop = true
         } else {
             if r.is_some() {
-                entity_manager.set_component_enabled(inv, true)?;
+                handle.set_component_enabled(inv, true)?;
             }
             wand.kill()
         }
@@ -2643,12 +2579,12 @@ fn give_wand(
     }
     if !stop {
         if r.is_some() {
-            entity_manager.set_component_enabled(inv, true)?;
+            handle.set_component_enabled(inv, true)?;
         }
         let (x, y) = entity.position()?;
         let wand = deserialize_entity(seri, x as f32, y as f32)?;
         if delete {
-            if let Some(pickup) = entity_manager
+            if let Some(pickup) = handle
                 .try_get_first_component_including_disabled::<ItemPickUpperComponent>(
                     ComponentTag::None,
                 )
@@ -2704,9 +2640,9 @@ fn give_wand(
     Ok(())
 }
 
-fn mom(entity: &mut EntityManager, counter: u8, cost: Option<i32>) -> eyre::Result<()> {
-    if entity.has_tag(const { CachedTag::from_tag("boss_wizard") }) {
-        for ent in entity.entity().children(None) {
+fn mom(handle: &mut EntityHandle, counter: u8, cost: Option<i32>) -> eyre::Result<()> {
+    if handle.has_tag(const { CachedTag::from_tag("boss_wizard") }) {
+        for ent in handle.entity().children(None) {
             if ent.has_tag("touchmagic_immunity")
                 && let Ok(var) = ent
                     .get_first_component_including_disabled::<VariableStorageComponent>(Some(
@@ -2733,51 +2669,38 @@ fn mom(entity: &mut EntityManager, counter: u8, cost: Option<i32>) -> eyre::Resu
     }
     Ok(())
 }
-fn sun(entity: &mut EntityManager, counter: u8) -> eyre::Result<()> {
-    if entity.has_tag(const { CachedTag::from_tag("seed_d") }) {
+fn sun(handle: &mut EntityHandle, counter: u8) -> eyre::Result<()> {
+    if handle.has_tag(const { CachedTag::from_tag("seed_d") }) {
         let essences =
-            entity.get_var_or_default(const { VarName::from_str("sunbaby_essences_list") })?;
+            handle.get_var_or_default(const { VarName::from_str("sunbaby_essences_list") })?;
+        let entity = handle.entity();
         let mut s = String::new();
         if counter & 1 == 1 {
             s += "water,";
-            entity
-                .entity()
-                .set_components_with_tag_enabled("water".into(), true)?;
+            entity.set_components_with_tag_enabled("water".into(), true)?;
         }
         if counter & 2 == 2 {
             s += "fire,";
-            entity
-                .entity()
-                .set_components_with_tag_enabled("fire".into(), true)?;
-            entity
-                .entity()
-                .set_components_with_tag_enabled("fire_disable".into(), false)?;
+            entity.set_components_with_tag_enabled("fire".into(), true)?;
+            entity.set_components_with_tag_enabled("fire_disable".into(), false)?;
         }
         if counter & 4 == 4 {
             s += "air,";
-            entity
-                .entity()
-                .set_components_with_tag_enabled("air".into(), true)?;
+            entity.set_components_with_tag_enabled("air".into(), true)?;
         }
         if counter & 8 == 8 {
             s += "earth,";
-            entity
-                .entity()
-                .set_components_with_tag_enabled("earth".into(), true)?;
-            entity
-                .entity()
-                .set_components_with_tag_enabled("earth_disable".into(), false)?;
+            entity.set_components_with_tag_enabled("earth".into(), true)?;
+            entity.set_components_with_tag_enabled("earth_disable".into(), false)?;
         }
         if counter & 16 == 16 {
             s += "poop,";
-            entity
-                .entity()
-                .set_components_with_tag_enabled("poop".into(), true)?;
+            entity.set_components_with_tag_enabled("poop".into(), true)?;
         }
         essences.set_value_string(s.into())?;
         let n = (counter & (32 + 64 + 128)) / 32;
         if counter != 0 {
-            let sprite = entity.get_first_component::<SpriteComponent>(
+            let sprite = handle.get_first_component::<SpriteComponent>(
                 const { ComponentTag::from_str("sunbaby_sprite") },
             )?;
             match n {

--- a/ewext/src/modules/entity_sync/diff_model.rs
+++ b/ewext/src/modules/entity_sync/diff_model.rs
@@ -1,4 +1,5 @@
 use super::NetManager;
+use super::sprite_animations::SpriteAnimations;
 use crate::{ephemerial, modules::ModuleCtx, my_peer_id, print_error};
 use bimap::BiHashMap;
 use eyre::{Context, OptionExt, eyre};
@@ -269,6 +270,7 @@ impl LocalDiffModelTracker {
         should_transfer: bool,
         ignore_transfer: bool,
         entity_manager: &mut EntityManager,
+        sprite_animations: &mut SpriteAnimations,
     ) -> eyre::Result<bool> {
         let entity = self
             .entity_by_lid(lid)
@@ -526,7 +528,6 @@ impl LocalDiffModelTracker {
                 info.ai_rotation = ai.m_ranged_attack_current_aim_angle()?;
             }
         } else {
-            let mut files = std::mem::take(&mut entity_manager.files);
             let sprites =
                 entity_manager.iter_all_components_of_type::<SpriteComponent>(ComponentTag::None);
             info.facing_direction = (sx.is_sign_positive(), sy.is_sign_positive());
@@ -534,22 +535,13 @@ impl LocalDiffModelTracker {
                 .filter_map(|sprite| {
                     let file = sprite.image_file().ok()?;
                     if file.ends_with(".xml") {
-                        let text = noita_api::get_file(&mut files, file).ok()?;
                         let animation = sprite.rect_animation().unwrap_or("".into());
-                        Some(
-                            text.iter()
-                                .position(|name| name == &animation)
-                                .unwrap_or(usize::MAX) as u16,
-                        )
+                        sprite_animations.index_of(file, &animation).ok()
                     } else {
                         None
                     }
                 })
                 .collect();
-            // Hand the map back before anything below can bail out: it is on
-            // loan from the manager, and `get_file` unwraps it, so an early
-            // return here takes the game down on the next entity.
-            entity_manager.files = files;
             if let Some(ai) =
                 entity_manager.try_get_first_component::<AnimalAIComponent>(ComponentTag::None)
                 && ai.attack_ranged_use_laser_sight()?
@@ -1103,6 +1095,7 @@ impl LocalDiffModel {
         start: usize,
         tmr: Instant,
         entity_manager: &mut EntityManager,
+        sprite_animations: &mut SpriteAnimations,
     ) -> eyre::Result<(Vec<(WorldPos, SpawnOnce)>, usize)> {
         self.update_buffer.clear();
         let (cam_x, cam_y) = entity_manager.camera_pos();
@@ -1168,6 +1161,7 @@ impl LocalDiffModel {
                     should_transfer && self.wait_to_transfer == 0,
                     !self.dont_save.contains(&lid),
                     entity_manager,
+                    sprite_animations,
                 )
                 .wrap_err("Failed to update local entity")
             {
@@ -1586,6 +1580,7 @@ impl RemoteDiffModel {
         entity: EntityID,
         lid: &Lid,
         entity_manager: &mut EntityManager,
+        sprite_animations: &mut SpriteAnimations,
     ) -> eyre::Result<Option<Lid>> {
         if entity_info.kind == EntityKind::Item && item_in_my_inventory(entity)?
             || item_in_entity_inventory(entity)?
@@ -1873,46 +1868,35 @@ impl RemoteDiffModel {
             ai.set_ai_state(entity_info.ai_state)?;
             ai.set_m_ranged_attack_current_aim_angle(entity_info.ai_rotation)?;
         } else {
-            let mut files = std::mem::take(&mut entity_manager.files);
-            // The map is on loan from the manager and `get_file` unwraps it, so
-            // every exit from this block has to hand it back - including the
-            // fallible ones, which is why the body is a closure.
-            let res = (|| -> eyre::Result<()> {
-                let sprites = entity_manager
-                    .iter_all_components_of_type::<SpriteComponent>(ComponentTag::None);
-                for (sprite, animation) in sprites
-                    .filter(|sprite| {
-                        sprite
-                            .image_file()
-                            .map(|c| c.ends_with(".xml"))
-                            .unwrap_or(false)
-                    })
-                    .zip(entity_info.animations.iter())
-                {
-                    sprite.set_special_scale_x(if entity_info.facing_direction.0 {
-                        1.0
-                    } else {
-                        -1.0
-                    })?;
-                    sprite.set_special_scale_y(if entity_info.facing_direction.1 {
-                        1.0
-                    } else {
-                        -1.0
-                    })?;
-                    if *animation == u16::MAX {
-                        continue;
-                    }
-                    let file = sprite.image_file()?;
-                    let text = noita_api::get_file(&mut files, file)?;
-                    if let Some(ani) = text.get(*animation as usize) {
-                        sprite.set_rect_animation(ani.into())?;
-                        sprite.set_next_rect_animation(ani.into())?;
-                    }
+            let sprites =
+                entity_manager.iter_all_components_of_type::<SpriteComponent>(ComponentTag::None);
+            for (sprite, animation) in sprites
+                .filter(|sprite| {
+                    sprite
+                        .image_file()
+                        .map(|c| c.ends_with(".xml"))
+                        .unwrap_or(false)
+                })
+                .zip(entity_info.animations.iter())
+            {
+                sprite.set_special_scale_x(if entity_info.facing_direction.0 {
+                    1.0
+                } else {
+                    -1.0
+                })?;
+                sprite.set_special_scale_y(if entity_info.facing_direction.1 {
+                    1.0
+                } else {
+                    -1.0
+                })?;
+                if *animation == u16::MAX {
+                    continue;
                 }
-                Ok(())
-            })();
-            entity_manager.files = files;
-            res?;
+                if let Some(ani) = sprite_animations.name_at(sprite.image_file()?, *animation)? {
+                    sprite.set_rect_animation(ani.into())?;
+                    sprite.set_next_rect_animation(ani.into())?;
+                }
+            }
         }
         let laser =
             entity_manager.try_get_first_component::<LaserEmitterComponent>(ComponentTag::None);
@@ -1963,6 +1947,7 @@ impl RemoteDiffModel {
         start: usize,
         tmr: Instant,
         entity_manager: &mut EntityManager,
+        sprite_animations: &mut SpriteAnimations,
     ) -> eyre::Result<usize> {
         let mut to_remove = Vec::new();
         let l = self.entity_infos.len();
@@ -2015,7 +2000,14 @@ impl RemoteDiffModel {
                             }
                         }
                     } else {
-                        match self.inner(ctx, entity_info, *entity, lid, entity_manager) {
+                        match self.inner(
+                            ctx,
+                            entity_info,
+                            *entity,
+                            lid,
+                            entity_manager,
+                            sprite_animations,
+                        ) {
                             Ok(Some(lid)) => to_remove.push(lid),
                             Err(s) => print_error(s)?,
                             _ => {}

--- a/ewext/src/modules/entity_sync/diff_model.rs
+++ b/ewext/src/modules/entity_sync/diff_model.rs
@@ -785,6 +785,48 @@ impl LocalDiffModel {
         gid: Gid,
         entity_manager: &mut EntityManager,
     ) -> eyre::Result<Lid> {
+        match self.track_entity_inner(entity, gid, entity_manager) {
+            Ok(lid) => Ok(lid),
+            Err(err) => {
+                // The map writes are safe now that they happen last, but the
+                // marks left on the entity itself are not: a failure part-way
+                // through leaves DES_TAG and an `ew_gid_lid` naming a lid that
+                // is registered nowhere. Those two are exactly what other peers
+                // read to decide that someone else owns this entity, so they
+                // would keep deferring to a peer that is not syncing it, and it
+                // would look tracked to any later attempt. Strip them so the
+                // entity is plainly untracked again.
+                if let Err(cleanup_err) = Self::undo_track_marks(entity, entity_manager) {
+                    return Err(err.wrap_err(format!(
+                        "additionally, undoing the partial tracking marks failed: {cleanup_err:?}"
+                    )));
+                }
+                Err(err)
+            }
+        }
+    }
+
+    /// Removes the tracking marks `track_entity_inner` may have written before
+    /// it failed.
+    ///
+    /// The lid itself is not reclaimed: `next_lid` only counts up and never
+    /// reuses a value, so a gap in it costs nothing, whereas handing the same
+    /// lid out twice would not.
+    fn undo_track_marks(entity: EntityID, entity_manager: &mut EntityManager) -> eyre::Result<()> {
+        let mut handle = entity_manager.handle(entity)?;
+        handle.remove_tag(const { CachedTag::from_tag(DES_TAG) })?;
+        if let Some(var) = handle.get_var(const { VarName::from_str("ew_gid_lid") }) {
+            handle.remove_component(var)?;
+        }
+        Ok(())
+    }
+
+    fn track_entity_inner(
+        &mut self,
+        entity: EntityID,
+        gid: Gid,
+        entity_manager: &mut EntityManager,
+    ) -> eyre::Result<Lid> {
         let mut handle = entity_manager.handle(entity)?;
         self.wait_to_transfer = 16;
         let lid = self.alloc_lid();

--- a/ewext/src/modules/entity_sync/diff_model.rs
+++ b/ewext/src/modules/entity_sync/diff_model.rs
@@ -852,12 +852,11 @@ impl LocalDiffModel {
                 "mods/quant.ew/files/system/entity_sync_helper/death_notify.lua".into(),
             )
         })?;
-        let n = entity_manager.get_var(const { VarName::from_str("ew_gid_lid") });
-        if let Some(lua) = n {
+        if let Some(lua) = entity_manager.get_var(const { VarName::from_str("ew_gid_lid") }) {
             entity_manager.remove_component(lua)?;
         }
-        let var = entity_manager.add_component::<VariableStorageComponent>()?;
-        var.set_name("ew_gid_lid".into())?;
+        let var = entity_manager
+            .add_component_with_var_name(const { VarName::from_str("ew_gid_lid") })?;
         var.set_value_string(gid.0.to_string().into())?;
         var.set_value_int(i32::from_le_bytes(lid.0.to_le_bytes()))?;
         var.set_value_bool(true)?;
@@ -1673,8 +1672,7 @@ impl RemoteDiffModel {
                     "mods/quant.ew/files/system/entity_sync_helper/immortal.lua".into(),
                 )?;
                 entity_manager
-                    .add_component::<VariableStorageComponent>()?
-                    .set_name("ew_has_started".into())?;
+                    .add_component_with_var_name(const { VarName::from_str("ew_has_started") })?;
                 entity
                     .children(Some("protection".into()))
                     .for_each(|ent| ent.kill());
@@ -2370,8 +2368,8 @@ pub fn init_remote_entity(
     }
 
     if let Some(lid) = lid {
-        let var = entity_manager.add_component::<VariableStorageComponent>()?;
-        var.set_name("ew_gid_lid".into())?;
+        let var = entity_manager
+            .add_component_with_var_name(const { VarName::from_str("ew_gid_lid") })?;
         if let Some(gid) = gid {
             var.set_value_string(gid.0.to_string().into())?;
         }

--- a/ewext/src/modules/entity_sync/diff_model.rs
+++ b/ewext/src/modules/entity_sync/diff_model.rs
@@ -984,7 +984,6 @@ impl LocalDiffModel {
                 entity
                     .children(Some("protection".into()))
                     .for_each(|ent| ent.kill());
-                handle.add_tag(const { CachedTag::from_tag("boss_centipede_active") })?;
                 entity.set_static(false)?
             }
         }
@@ -1007,6 +1006,11 @@ impl LocalDiffModel {
             entity.set_position(entity_data.pos.x as f64, entity_data.pos.y as f64, None)?;
             if entity_data.is_charmed {
                 if handle.has_tag(const { CachedTag::from_tag("boss_centipede") }) {
+                    // Tagged here rather than in enable_later: kolmi.lua starts the
+                    // fight on any Kolmi this peer owns that lacks the tag, and this
+                    // one is owned by the end of this loop but its components only
+                    // come on next frame.
+                    handle.add_tag(const { CachedTag::from_tag("boss_centipede_active") })?;
                     self.enable_later.push(entity);
                 } else if handle.has_tag(const { CachedTag::from_tag("pitcheck_b") }) {
                     handle.set_components_with_tag_enabled(

--- a/ewext/src/modules/entity_sync/diff_model.rs
+++ b/ewext/src/modules/entity_sync/diff_model.rs
@@ -2,7 +2,7 @@ use super::NetManager;
 use crate::{ephemerial, modules::ModuleCtx, my_peer_id, print_error};
 use bimap::BiHashMap;
 use eyre::{Context, OptionExt, eyre};
-use noita_api::raw::raytrace_platforms;
+use noita_api::raw::{does_world_exist_at, raytrace_platforms};
 use noita_api::serialize::{deserialize_entity, serialize_entity};
 use noita_api::{
     AIAttackComponent, AbilityComponent, AdvancedFishAIComponent, AnimalAIComponent,
@@ -12,8 +12,9 @@ use noita_api::{
     IKLimbAttackerComponent, IKLimbComponent, IKLimbWalkerComponent, IKLimbsAnimatorComponent,
     Inventory2Component, ItemComponent, ItemCostComponent, ItemPickUpperComponent,
     LaserEmitterComponent, LifetimeComponent, LuaComponent, PhysData, PhysicsAIComponent,
-    PhysicsBody2Component, PhysicsBodyComponent, SpriteComponent, StreamingKeepAliveComponent,
-    VarName, VariableStorageComponent, VelocityComponent, WormComponent, game_print,
+    PhysicsBody2Component, PhysicsBodyComponent, SimplePhysicsComponent, SpriteComponent,
+    StreamingKeepAliveComponent, VarName, VariableStorageComponent, VelocityComponent,
+    WormComponent, game_print,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use shared::des::{
@@ -406,18 +407,8 @@ impl LocalDiffModelTracker {
             (info.vx, info.vy) = vel.m_velocity()?;
         }
 
-        if entity_manager.has_tag(const { CachedTag::from_tag("card_action") })
-            && let Some(vel) =
-                entity_manager.try_get_first_component::<VelocityComponent>(ComponentTag::None)
-        {
-            let (cx, cy) = entity_manager.camera_pos();
-            if ((cx - x) as f32).powi(2) + ((cy - y) as f32).powi(2) > 512.0 * 512.0 {
-                vel.set_gravity_y(0.0)?;
-                vel.set_air_friction(10.0)?;
-            } else {
-                vel.set_gravity_y(400.0)?;
-                vel.set_air_friction(0.55)?;
-            }
+        if info.kind == EntityKind::Item && !item_and_was_picked {
+            hold_over_ungenerated_world(entity_manager, x, y)?;
         }
 
         if let Some(damage) =
@@ -633,6 +624,11 @@ impl LocalDiffModelTracker {
                 }
             }
         }
+        // Gravity used to be driven off this countdown, which gave a spell 48
+        // frames of hovering after it was spawned and then dropped it whether or
+        // not there was anything under it yet. hold_over_ungenerated_world above
+        // waits for the terrain instead; this only decides when a shop item
+        // becomes stealable again.
         if let Some(var) = entity_manager.get_var(const { VarName::from_str("ew_was_stealable") }) {
             let n = var.value_int()?;
             if n == 1 {
@@ -645,28 +641,10 @@ impl LocalDiffModelTracker {
                         entity_manager.remove_component(var)?;
                     }
                 }
-                if let Some(vel) =
-                    entity_manager.try_get_first_component::<VelocityComponent>(ComponentTag::None)
-                {
-                    vel.set_gravity_y(400.0)?;
-                    vel.set_air_friction(0.55)?;
-                }
             } else if n == 0 {
                 var.set_value_int(48)?;
-                if let Some(vel) =
-                    entity_manager.try_get_first_component::<VelocityComponent>(ComponentTag::None)
-                {
-                    vel.set_gravity_y(0.0)?;
-                    vel.set_air_friction(10.0)?;
-                }
             } else {
                 var.set_value_int(n - 1)?;
-                if let Some(vel) =
-                    entity_manager.try_get_first_component::<VelocityComponent>(ComponentTag::None)
-                {
-                    vel.set_gravity_y(0.0)?;
-                    vel.set_air_friction(10.0)?;
-                }
             }
         }
         Ok(false)
@@ -883,12 +861,10 @@ impl LocalDiffModel {
         var.set_value_int(i32::from_le_bytes(lid.0.to_le_bytes()))?;
         var.set_value_bool(true)?;
 
-        if entity_manager.has_tag(const { CachedTag::from_tag("card_action") })
-            && let Some(vel) =
-                entity_manager.try_get_first_component::<VelocityComponent>(ComponentTag::None)
-        {
-            vel.set_gravity_y(0.0)?;
-            vel.set_air_friction(10.0)?;
+        // Must come after spawn_info was serialized above, or every peer that
+        // later spawns this item from that data inherits the disabled physics.
+        if entity_kind == EntityKind::Item && !item_in_inventory(entity)? {
+            hold_over_ungenerated_world(entity_manager, x, y)?;
         }
 
         if entity_manager
@@ -2400,6 +2376,57 @@ pub fn init_remote_entity(
         ephemerial(entity.0.get() as u32)?
     }
 
+    Ok(())
+}
+
+/// Keeps an item still while there is no world under it to land on.
+///
+/// A holy mountain hands us its shop items - and an authority transfer hands us
+/// items a leaving peer was tracking - as soon as the entities exist, which can
+/// be well before our own copy of the chunk they sit in has generated. Noita
+/// gives them nothing to collide with in the meantime, so they fall straight
+/// through and are already below the shop by the time the terrain pops in. Since
+/// the peer with authority is the one everybody else copies positions from, one
+/// slow generation is enough to lose the wands for the whole lobby.
+///
+/// Disabling SimplePhysicsComponent (which both wands and cards have) stops the
+/// fall and keeps explosions from moving the item, and Noita enables it again
+/// by itself when the item is dropped from an inventory. `ew_no_ground` marks
+/// items we disabled it on, so one that was already disabled - like a wand
+/// placed by EZWand - is left alone once the world shows up.
+fn hold_over_ungenerated_world(
+    entity_manager: &mut EntityManager,
+    x: f64,
+    y: f64,
+) -> eyre::Result<()> {
+    let held = entity_manager.get_var(const { VarName::from_str("ew_no_ground") });
+    let has_world = does_world_exist_at(
+        (x - 4.0) as i32,
+        (y - 4.0) as i32,
+        (x + 4.0) as i32,
+        (y + 8.0) as i32,
+    )?;
+    match (has_world, held) {
+        (false, None) => {
+            if let Some(physics) =
+                entity_manager.try_get_first_component::<SimplePhysicsComponent>(ComponentTag::None)
+            {
+                entity_manager.set_component_enabled(physics, false)?;
+                entity_manager.get_var_or_default(const { VarName::from_str("ew_no_ground") })?;
+            }
+        }
+        (true, Some(var)) => {
+            if let Some(physics) = entity_manager
+                .try_get_first_component_including_disabled::<SimplePhysicsComponent>(
+                    ComponentTag::None,
+                )
+            {
+                entity_manager.set_component_enabled(physics, true)?;
+            }
+            entity_manager.remove_component(var)?;
+        }
+        _ => {}
+    }
     Ok(())
 }
 

--- a/ewext/src/modules/entity_sync/diff_model.rs
+++ b/ewext/src/modules/entity_sync/diff_model.rs
@@ -546,6 +546,10 @@ impl LocalDiffModelTracker {
                     }
                 })
                 .collect();
+            // Hand the map back before anything below can bail out: it is on
+            // loan from the manager, and `get_file` unwraps it, so an early
+            // return here takes the game down on the next entity.
+            entity_manager.files = files;
             if let Some(ai) =
                 entity_manager.try_get_first_component::<AnimalAIComponent>(ComponentTag::None)
                 && ai.attack_ranged_use_laser_sight()?
@@ -569,7 +573,6 @@ impl LocalDiffModelTracker {
                     Target::None
                 }
             }
-            entity_manager.files = files;
         }
 
         info.synced_var = entity_manager
@@ -1870,38 +1873,45 @@ impl RemoteDiffModel {
             ai.set_m_ranged_attack_current_aim_angle(entity_info.ai_rotation)?;
         } else {
             let mut files = std::mem::take(&mut entity_manager.files);
-            let sprites =
-                entity_manager.iter_all_components_of_type::<SpriteComponent>(ComponentTag::None);
-            for (sprite, animation) in sprites
-                .filter(|sprite| {
-                    sprite
-                        .image_file()
-                        .map(|c| c.ends_with(".xml"))
-                        .unwrap_or(false)
-                })
-                .zip(entity_info.animations.iter())
-            {
-                sprite.set_special_scale_x(if entity_info.facing_direction.0 {
-                    1.0
-                } else {
-                    -1.0
-                })?;
-                sprite.set_special_scale_y(if entity_info.facing_direction.1 {
-                    1.0
-                } else {
-                    -1.0
-                })?;
-                if *animation == u16::MAX {
-                    continue;
+            // The map is on loan from the manager and `get_file` unwraps it, so
+            // every exit from this block has to hand it back - including the
+            // fallible ones, which is why the body is a closure.
+            let res = (|| -> eyre::Result<()> {
+                let sprites = entity_manager
+                    .iter_all_components_of_type::<SpriteComponent>(ComponentTag::None);
+                for (sprite, animation) in sprites
+                    .filter(|sprite| {
+                        sprite
+                            .image_file()
+                            .map(|c| c.ends_with(".xml"))
+                            .unwrap_or(false)
+                    })
+                    .zip(entity_info.animations.iter())
+                {
+                    sprite.set_special_scale_x(if entity_info.facing_direction.0 {
+                        1.0
+                    } else {
+                        -1.0
+                    })?;
+                    sprite.set_special_scale_y(if entity_info.facing_direction.1 {
+                        1.0
+                    } else {
+                        -1.0
+                    })?;
+                    if *animation == u16::MAX {
+                        continue;
+                    }
+                    let file = sprite.image_file()?;
+                    let text = noita_api::get_file(&mut files, file)?;
+                    if let Some(ani) = text.get(*animation as usize) {
+                        sprite.set_rect_animation(ani.into())?;
+                        sprite.set_next_rect_animation(ani.into())?;
+                    }
                 }
-                let file = sprite.image_file()?;
-                let text = noita_api::get_file(&mut files, file)?;
-                if let Some(ani) = text.get(*animation as usize) {
-                    sprite.set_rect_animation(ani.into())?;
-                    sprite.set_next_rect_animation(ani.into())?;
-                }
-            }
+                Ok(())
+            })();
             entity_manager.files = files;
+            res?;
         }
         let laser =
             entity_manager.try_get_first_component::<LaserEmitterComponent>(ComponentTag::None);

--- a/ewext/src/modules/entity_sync/diff_model.rs
+++ b/ewext/src/modules/entity_sync/diff_model.rs
@@ -1664,13 +1664,13 @@ impl RemoteDiffModel {
                 limb.set_end_position((*x, *y))?;
             }
             if let Ok(limb) = ent.get_first_component::<IKLimbWalkerComponent>(None) {
-                handle.remove_component(limb)?
+                ent.remove_component(*limb)?
             };
             if let Ok(limb) = ent.get_first_component::<IKLimbAttackerComponent>(None) {
-                handle.remove_component(limb)?
+                ent.remove_component(*limb)?
             };
             if let Ok(limb) = ent.get_first_component::<IKLimbsAnimatorComponent>(None) {
-                handle.remove_component(limb)?
+                ent.remove_component(*limb)?
             };
         }
         let m = *ctx.fps_by_player.get(&self.peer_id).unwrap_or(&60) as f32

--- a/ewext/src/modules/entity_sync/diff_model.rs
+++ b/ewext/src/modules/entity_sync/diff_model.rs
@@ -362,21 +362,23 @@ impl LocalDiffModelTracker {
                 info.wand = None;
             };
         }
+        // Both component checks ask the game, not the cache. What they look for
+        // is switched on from Lua - sampo_pickup.lua starts Kolmi's fight and
+        // orb_07_pitcheck_a.lua arms the pit trigger - so the cache would keep
+        // reporting neither as started.
         info.is_enabled = (handle.has_tag(const { CachedTag::from_tag("boss_centipede") })
-            && handle
-                .try_get_first_component::<BossHealthBarComponent>(
-                    const { ComponentTag::from_str("disabled_at_start") },
-                )
+            && entity
+                .try_get_first_component::<BossHealthBarComponent>(Some(
+                    "disabled_at_start".into(),
+                ))?
                 .is_some())
             || handle
                 .get_var(const { VarName::from_str("active") })
                 .map(|var| var.value_int().unwrap_or(0) == 1)
                 .unwrap_or(false)
             || (handle.has_tag(const { CachedTag::from_tag("pitcheck_b") })
-                && handle
-                    .try_get_first_component::<LuaComponent>(
-                        const { ComponentTag::from_str("disabled") },
-                    )
+                && entity
+                    .try_get_first_component::<LuaComponent>(Some("disabled".into()))?
                     .is_some());
 
         info.limbs = entity
@@ -1007,9 +1009,10 @@ impl LocalDiffModel {
                 if handle.has_tag(const { CachedTag::from_tag("boss_centipede") }) {
                     self.enable_later.push(entity);
                 } else if handle.has_tag(const { CachedTag::from_tag("pitcheck_b") }) {
-                    handle
-                        .entity()
-                        .set_components_with_tag_enabled("disabled".into(), true)?;
+                    handle.set_components_with_tag_enabled(
+                        const { ComponentTag::from_str("disabled") },
+                        true,
+                    )?;
                 } else if let Some(var) = handle.get_var(const { VarName::from_str("active") }) {
                     var.set_value_int(1)?;
                     handle.set_components_with_tag_enabled(

--- a/ewext/src/modules/entity_sync/diff_model.rs
+++ b/ewext/src/modules/entity_sync/diff_model.rs
@@ -2532,7 +2532,8 @@ fn with_entity_scripts<T>(
         c
     } else {
         let component = entity.add_component::<LuaComponent>()?;
-        component.add_tag(DES_SCRIPTS_TAG)?;
+        // Through the manager, so the lookup above can find it next time.
+        entity.add_component_tag(component, const { ComponentTag::from_str(DES_SCRIPTS_TAG) })?;
         component.add_tag("enabled_in_inventory")?;
         component.add_tag("enabled_in_world")?;
         component.add_tag("enabled_in_hand")?;

--- a/ewext/src/modules/entity_sync/diff_model.rs
+++ b/ewext/src/modules/entity_sync/diff_model.rs
@@ -826,8 +826,6 @@ impl LocalDiffModel {
             ghost.set_target_tag("".into())?;
         }
 
-        self.tracker.tracked.insert(lid, entity);
-
         let (x, y) = entity.position()?;
 
         if entity_manager.has_tag(const { CachedTag::from_tag("card_action") })
@@ -889,10 +887,6 @@ impl LocalDiffModel {
                 .try_get_first_component::<StreamingKeepAliveComponent>(ComponentTag::None)
                 .is_some();
 
-        if is_global {
-            self.tracker.global_entities.insert(entity);
-        }
-
         let drops_gold = (entity_manager
             .iter_all_components_of_type::<LuaComponent>(ComponentTag::None)
             .any(|lua| {
@@ -913,6 +907,15 @@ impl LocalDiffModel {
                 .map(|v| v.value_int().ok() != Some(-1))
                 .unwrap_or(false);
 
+        // Registration is committed only here, once everything fallible above
+        // has succeeded. The maps have to agree: a lid in `tracked` but not in
+        // `entity_entries` is an entity this peer owns, tagged and given an
+        // `ew_gid_lid` so other peers defer to it, that `update_tracked_entities`
+        // never walks and so never syncs again.
+        self.tracker.tracked.insert(lid, entity);
+        if is_global {
+            self.tracker.global_entities.insert(entity);
+        }
         self.entity_entries.insert(
             lid,
             EntityEntryPair {

--- a/ewext/src/modules/entity_sync/sprite_animations.rs
+++ b/ewext/src/modules/entity_sync/sprite_animations.rs
@@ -1,0 +1,58 @@
+use noita_api::raw::mod_text_file_get_content;
+use rustc_hash::FxHashMap;
+use std::borrow::Cow;
+use std::collections::hash_map::Entry;
+
+/// Animation names read out of sprite xml files, so a sprite's animation can
+/// go over the wire as a position in its file's list rather than as a string.
+///
+/// The list is every `name="..."` value in the file, in order - which also
+/// picks up things like the `filename="..."` attribute. Only the positions have
+/// to agree, and both peers parse the same file the same way, so they do.
+#[derive(Default)]
+pub(crate) struct SpriteAnimations {
+    files: FxHashMap<Cow<'static, str>, Vec<String>>,
+}
+
+impl SpriteAnimations {
+    /// Where `animation` sits in `file`'s list, or `u16::MAX` if it isn't there.
+    pub(crate) fn index_of(
+        &mut self,
+        file: Cow<'static, str>,
+        animation: &str,
+    ) -> eyre::Result<u16> {
+        Ok(self
+            .names(file)?
+            .iter()
+            .position(|name| name == animation)
+            .and_then(|i| u16::try_from(i).ok())
+            .unwrap_or(u16::MAX))
+    }
+
+    /// The name at `index` in `file`'s list, if the list is that long.
+    pub(crate) fn name_at(
+        &mut self,
+        file: Cow<'static, str>,
+        index: u16,
+    ) -> eyre::Result<Option<&str>> {
+        Ok(self.names(file)?.get(index as usize).map(String::as_str))
+    }
+
+    fn names(&mut self, file: Cow<'static, str>) -> eyre::Result<&[String]> {
+        match self.files.entry(file) {
+            Entry::Occupied(entry) => Ok(entry.into_mut()),
+            Entry::Vacant(entry) => {
+                let content = mod_text_file_get_content(entry.key().clone())?;
+                // A value missing its closing quote means a malformed file.
+                // Stop the list there instead of panicking; every peer reading
+                // the same file stops at the same place.
+                let names = content
+                    .split("name=\"")
+                    .skip(1)
+                    .map_while(|piece| piece.split_once('"').map(|(name, _)| name.to_string()))
+                    .collect();
+                Ok(entry.insert(names))
+            }
+        }
+    }
+}

--- a/noita_api/src/lib.rs
+++ b/noita_api/src/lib.rs
@@ -1008,8 +1008,9 @@ pub enum CachedComponent {
     AudioComponent,
     AbilityComponent,
     StatusEffectDataComponent,
+    SimplePhysicsComponent,
 }
-const COMP_LEN: usize = 32;
+const COMP_LEN: usize = 33;
 impl CachedComponent {
     const fn from_component<C: Component>() -> Self {
         match C::NAME_STR.as_bytes() {
@@ -1045,6 +1046,7 @@ impl CachedComponent {
             b"AudioComponent" => Self::AudioComponent,
             b"AbilityComponent" => Self::AbilityComponent,
             b"StatusEffectDataComponent" => Self::StatusEffectDataComponent,
+            b"SimplePhysicsComponent" => Self::SimplePhysicsComponent,
             _ => unreachable!(),
         }
     }
@@ -1082,6 +1084,7 @@ impl CachedComponent {
             "AudioComponent" => Self::AudioComponent,
             "AbilityComponent" => Self::AbilityComponent,
             "StatusEffectDataComponent" => Self::StatusEffectDataComponent,
+            "SimplePhysicsComponent" => Self::SimplePhysicsComponent,
             _ => return None,
         })
     }
@@ -1098,6 +1101,7 @@ pub enum VarName {
     EwGidLid,
     Active,
     EwHasStarted,
+    EwNoGround,
     Unknown,
 }
 impl VarName {
@@ -1112,6 +1116,7 @@ impl VarName {
             b"ew_gid_lid" => Self::EwGidLid,
             b"active" => Self::Active,
             b"ew_has_started" => Self::EwHasStarted,
+            b"ew_no_ground" => Self::EwNoGround,
             _ => unreachable!(),
         }
     }
@@ -1126,6 +1131,7 @@ impl VarName {
             b"ew_gid_lid" => Self::EwGidLid,
             b"active" => Self::Active,
             b"ew_has_started" => Self::EwHasStarted,
+            b"ew_no_ground" => Self::EwNoGround,
             _ if s.is_empty() => Self::None,
             _ => Self::Unknown,
         }
@@ -1142,6 +1148,7 @@ impl VarName {
             Self::EwGidLid => "ew_gid_lid",
             Self::Active => "active",
             Self::EwHasStarted => "ew_has_started",
+            Self::EwNoGround => "ew_no_ground",
             Self::Unknown => unreachable!(),
         }
     }
@@ -1259,11 +1266,20 @@ impl ComponentData {
     }
 }
 const COMP_VEC_LEN: usize = 1;
-#[derive(Default)]
 struct EntityData {
     tags: Tags<u16>, //[bool; TAG_LEN],
     phys_init: bool,
     components: [SmallVec<[ComponentData; COMP_VEC_LEN]>; COMP_LEN],
+}
+// Arrays only implement Default up to 32 elements, so this can't be derived.
+impl Default for EntityData {
+    fn default() -> Self {
+        Self {
+            tags: Tags(0),
+            phys_init: false,
+            components: std::array::from_fn(|_| SmallVec::new()),
+        }
+    }
 }
 pub struct EntityManager {
     cache: FxHashMap<EntityID, EntityData>,

--- a/noita_api/src/lib.rs
+++ b/noita_api/src/lib.rs
@@ -1260,7 +1260,10 @@ impl ComponentData {
         }
     }
     fn new_with_name(id: ComponentID, name: VarName) -> Self {
-        let mut c = Self::new(id, true);
+        // `false` because the caller already knows the name: asking Noita for it
+        // is a lua call whose answer is overwritten on the next line, and on a
+        // freshly added component that answer is empty anyway.
+        let mut c = Self::new(id, false);
         c.name = name;
         c
     }
@@ -1767,6 +1770,29 @@ impl EntityManager {
             c.tags.set(tag as u16);
         }
         Ok(())
+    }
+    /// Adds a named `VariableStorageComponent` to the current entity, keeping the
+    /// snapshot in step.
+    ///
+    /// Naming it through the raw `ComponentID` afterwards instead leaves the
+    /// snapshot's name as it was when the component was added - `VarName::None`,
+    /// since a component is unnamed until Noita is told otherwise - so `get_var`
+    /// never finds it again and callers that remove-then-add pile up duplicates.
+    ///
+    /// Only for names `VarName` knows: `VarName::Unknown` has no string to write -
+    /// that is what `get_var_or_default_unknown` is for - and `VarName::None` would
+    /// name the component the empty string, which is what it is called already.
+    pub fn add_component_with_var_name(
+        &mut self,
+        name: VarName,
+    ) -> eyre::Result<VariableStorageComponent> {
+        let var = if self.bypass_cache {
+            self.entity().add_component::<VariableStorageComponent>()?
+        } else {
+            self.add_component_var::<VariableStorageComponent>(name)?
+        };
+        var.set_name(name.to_str().into())?;
+        Ok(var)
     }
     pub fn set_components_with_tag_enabled(
         &mut self,

--- a/noita_api/src/lib.rs
+++ b/noita_api/src/lib.rs
@@ -1391,21 +1391,30 @@ impl EntityManager {
             self.current_entity = ent;
             return Ok(());
         }
-        if self.current_entity == ent {
+        // `has_ran` matters here: after `remove_current`, `current_entity` still
+        // names the dropped entity, so an early return would keep serving its
+        // stale `current_data`.
+        if self.current_entity == ent && self.has_ran {
             return Ok(());
         }
         if self.has_ran {
-            let old_ent = std::mem::replace(&mut self.current_entity, ent);
+            // Build the new data *before* touching any field. On failure the
+            // manager must stay consistent - a half-applied switch leaves
+            // `current_entity` pointing at `ent` while `current_data` still
+            // describes the old one, and the next switch caches that mismatch
+            // under `ent` for good.
             let data = if let Some(data) = self.cache.remove(&ent) {
                 data
             } else {
                 EntityData::new(ent)?
             };
+            let old_ent = std::mem::replace(&mut self.current_entity, ent);
             let old_data = std::mem::replace(&mut self.current_data, data);
             self.cache.insert(old_ent, old_data);
         } else {
+            let data = EntityData::new(ent)?;
             self.current_entity = ent;
-            self.current_data = EntityData::new(ent)?;
+            self.current_data = data;
             self.has_ran = true;
         }
         Ok(())

--- a/noita_api/src/lib.rs
+++ b/noita_api/src/lib.rs
@@ -1423,12 +1423,19 @@ impl EntityManager {
     pub fn entity(&self) -> EntityID {
         self.current_entity
     }
+    /// Drops the snapshot for the current entity.
+    ///
+    /// `current_entity` deliberately keeps naming it - callers still want
+    /// `entity()` afterwards - so the snapshot has to be emptied rather than
+    /// just marked invalid. No accessor consults `has_ran`, and every one of
+    /// them would otherwise keep answering from a dead entity's components.
     pub fn remove_current(&mut self) {
         self.has_ran = false;
+        self.current_data = EntityData::default();
     }
     pub fn remove_ent(&mut self, ent: &EntityID) {
         if &self.current_entity == ent || self.bypass_cache {
-            self.has_ran = false;
+            self.remove_current();
         } else {
             self.cache.remove(ent);
         }
@@ -1564,20 +1571,29 @@ impl EntityManager {
                 },
             );
         }
+        let idx = const { CachedComponent::from_component::<C>() as usize };
         let mut is_some = false;
-        let vec = std::mem::take(
-            &mut self.current_data.components[const { CachedComponent::from_component::<C>() as usize }],
-        );
+        let mut err = None;
+        let vec = std::mem::take(&mut self.current_data.components[idx]);
         for com in vec.into_iter() {
-            if tags == ComponentTag::None || com.tags.get(tags as u16) {
-                is_some = true;
-                self.current_entity.remove_component(com.id)?;
-            } else {
-                self.current_data.components
-                    [const { CachedComponent::from_component::<C>() as usize }].push(com);
+            // Once a removal has failed, stop removing but keep every entry:
+            // the components are still on the entity, and dropping them from
+            // the snapshot only makes the cache lie about a smaller entity.
+            if err.is_none() && (tags == ComponentTag::None || com.tags.get(tags as u16)) {
+                match self.current_entity.remove_component(com.id) {
+                    Ok(()) => {
+                        is_some = true;
+                        continue;
+                    }
+                    Err(e) => err = Some(e),
+                }
             }
+            self.current_data.components[idx].push(com);
         }
-        Ok(is_some)
+        match err {
+            Some(e) => Err(e),
+            None => Ok(is_some),
+        }
     }
     pub fn iter_all_components_of_type<C: Component>(
         &self,
@@ -1727,6 +1743,31 @@ impl EntityManager {
             .push(ComponentData::new(*c, false));
         Ok(c)
     }
+    /// Tags a component of the current entity, keeping the snapshot in step.
+    ///
+    /// Tagging through the raw `ComponentID` instead leaves the snapshot's tag
+    /// bitset as it was when the component was added - empty, for one added
+    /// through this manager - so lookups by that tag never find it again and
+    /// callers that add-if-missing add forever.
+    pub fn add_component_tag<C: Component>(
+        &mut self,
+        com: C,
+        tag: ComponentTag,
+    ) -> eyre::Result<()> {
+        com.add_tag(tag.to_str())?;
+        if self.bypass_cache {
+            return Ok(());
+        }
+        let id = *com;
+        if let Some(c) = self.current_data.components
+            [const { CachedComponent::from_component::<C>() as usize }]
+        .iter_mut()
+        .find(|c| c.id == id)
+        {
+            c.tags.set(tag as u16);
+        }
+        Ok(())
+    }
     pub fn set_components_with_tag_enabled(
         &mut self,
         tag: ComponentTag,
@@ -1737,18 +1778,17 @@ impl EntityManager {
                 .entity()
                 .set_components_with_tag_enabled(tag.to_str().into(), enabled);
         }
-        let mut some = false;
         for c in self.current_data.components.iter_mut().flatten() {
             if c.tags.get(tag as u16) {
-                some = true;
                 c.enabled = enabled
             }
         }
-        if some {
-            self.current_entity
-                .set_components_with_tag_enabled(tag.to_str().into(), enabled)?
-        }
-        Ok(())
+        // Unconditionally, not just when the snapshot knew about a tagged
+        // component. Only 32 component types are cached at all, so "the
+        // snapshot has none" is the normal case for most tags, and gating on it
+        // turned this into a silent no-op that still returned Ok.
+        self.current_entity
+            .set_components_with_tag_enabled(tag.to_str().into(), enabled)
     }
     pub fn set_component_enabled<C: Component>(
         &mut self,

--- a/noita_api/src/lib.rs
+++ b/noita_api/src/lib.rs
@@ -1387,12 +1387,12 @@ impl EntityManager {
     pub fn camera_pos(&self) -> (f64, f64) {
         self.camera_pos
     }
-    pub fn set_current_entity(&mut self, ent: EntityID) -> eyre::Result<()> {
+    fn set_current_entity(&mut self, ent: EntityID) -> eyre::Result<()> {
         if self.bypass_cache {
             self.current_entity = ent;
             return Ok(());
         }
-        // `has_ran` matters here: after `remove_current`, `current_entity` still
+        // `has_ran` matters here: after `clear_current`, `current_entity` still
         // names the dropped entity, so an early return would keep serving its
         // stale `current_data`.
         if self.current_entity == ent && self.has_ran {
@@ -1420,54 +1420,78 @@ impl EntityManager {
         }
         Ok(())
     }
-    #[inline]
-    pub fn entity(&self) -> EntityID {
-        self.current_entity
+    /// Everything that reads or changes a single entity goes through the handle
+    /// this returns, so the entity a call is about is always named where the
+    /// handle is taken. The handle borrows the manager, so nothing can switch
+    /// to another entity while it is alive.
+    pub fn handle(&mut self, ent: EntityID) -> eyre::Result<EntityHandle<'_>> {
+        self.set_current_entity(ent)?;
+        Ok(EntityHandle { manager: self })
     }
     /// Drops the snapshot for the current entity.
     ///
-    /// `current_entity` deliberately keeps naming it - callers still want
-    /// `entity()` afterwards - so the snapshot has to be emptied rather than
-    /// just marked invalid. No accessor consults `has_ran`, and every one of
-    /// them would otherwise keep answering from a dead entity's components.
-    pub fn remove_current(&mut self) {
+    /// The snapshot has to be emptied rather than just marked invalid: no
+    /// accessor consults `has_ran`, and every one of them would otherwise keep
+    /// answering from a dead entity's components.
+    fn clear_current(&mut self) {
         self.has_ran = false;
         self.current_data = EntityData::default();
     }
     pub fn remove_ent(&mut self, ent: &EntityID) {
         if &self.current_entity == ent || self.bypass_cache {
-            self.remove_current();
+            self.clear_current();
         } else {
             self.cache.remove(ent);
         }
     }
+}
+/// One entity, read and changed through the manager's snapshot of it.
+pub struct EntityHandle<'a> {
+    manager: &'a mut EntityManager,
+}
+impl EntityHandle<'_> {
+    #[inline]
+    pub fn entity(&self) -> EntityID {
+        self.manager.current_entity
+    }
+    /// Drops the manager's snapshot of this entity, for when it is being
+    /// killed. Consumes the handle so nothing can read the emptied snapshot.
+    pub fn forget(self) {
+        self.manager.clear_current();
+    }
+    pub fn frame_num(&self) -> i32 {
+        self.manager.frame_num
+    }
+    pub fn camera_pos(&self) -> (f64, f64) {
+        self.manager.camera_pos
+    }
     pub fn add_tag(&mut self, tag: CachedTag) -> eyre::Result<()> {
-        self.current_entity.add_tag(tag.to_tag())?;
-        if self.bypass_cache {
+        self.manager.current_entity.add_tag(tag.to_tag())?;
+        if self.manager.bypass_cache {
             return Ok(());
         }
-        self.current_data.add_tag(tag);
+        self.manager.current_data.add_tag(tag);
         Ok(())
     }
     pub fn has_tag(&self, tag: CachedTag) -> bool {
-        if self.bypass_cache {
+        if self.manager.bypass_cache {
             return self.entity().has_tag(tag.to_tag());
         }
-        self.current_data.has_tag(tag)
+        self.manager.current_data.has_tag(tag)
     }
     pub fn remove_tag(&mut self, tag: CachedTag) -> eyre::Result<()> {
-        self.current_entity.remove_tag(tag.to_tag())?;
-        if self.bypass_cache {
+        self.manager.current_entity.remove_tag(tag.to_tag())?;
+        if self.manager.bypass_cache {
             return Ok(());
         }
-        self.current_data.remove_tag(tag);
+        self.manager.current_data.remove_tag(tag);
         Ok(())
     }
     pub fn check_all_phys_init(&mut self) -> eyre::Result<bool> {
-        if self.bypass_cache {
+        if self.manager.bypass_cache {
             return self.entity().check_all_phys_init();
         }
-        if self.current_data.phys_init {
+        if self.manager.current_data.phys_init {
             return Ok(true);
         }
         for phys_c in self.iter_mut_all_components_of_type::<PhysicsBody2Component>() {
@@ -1475,11 +1499,11 @@ impl EntityManager {
                 return Ok(false);
             }
         }
-        self.current_data.phys_init = true;
+        self.manager.current_data.phys_init = true;
         Ok(true)
     }
     pub fn try_get_first_component<C: Component>(&self, tag: ComponentTag) -> Option<C> {
-        if self.bypass_cache {
+        if self.manager.bypass_cache {
             return self
                 .entity()
                 .try_get_first_component::<C>(if matches!(tag, ComponentTag::None) {
@@ -1489,7 +1513,7 @@ impl EntityManager {
                 })
                 .unwrap_or(None);
         }
-        self.current_data.components[const { CachedComponent::from_component::<C>() as usize }]
+        self.manager.current_data.components[const { CachedComponent::from_component::<C>() as usize }]
             .iter()
             .find(|c| c.enabled && (tag == ComponentTag::None || c.tags.get(tag as u16)))
             .map(|com| C::from(com.id))
@@ -1498,7 +1522,7 @@ impl EntityManager {
         &self,
         tag: ComponentTag,
     ) -> Option<C> {
-        if self.bypass_cache {
+        if self.manager.bypass_cache {
             return self
                 .entity()
                 .try_get_first_component_including_disabled::<C>(
@@ -1510,13 +1534,13 @@ impl EntityManager {
                 )
                 .unwrap_or(None);
         }
-        self.current_data.components[const { CachedComponent::from_component::<C>() as usize }]
+        self.manager.current_data.components[const { CachedComponent::from_component::<C>() as usize }]
             .iter()
             .find(|c| tag == ComponentTag::None || c.tags.get(tag as u16))
             .map(|c| C::from(c.id))
     }
     pub fn get_first_component<C: Component>(&self, tag: ComponentTag) -> eyre::Result<C> {
-        if self.bypass_cache {
+        if self.manager.bypass_cache {
             return self
                 .entity()
                 .get_first_component::<C>(if matches!(tag, ComponentTag::None) {
@@ -1525,7 +1549,7 @@ impl EntityManager {
                     Some(tag.to_str().into())
                 });
         }
-        if let Some(coms) = self.current_data.components
+        if let Some(coms) = self.manager.current_data.components
             [const { CachedComponent::from_component::<C>() as usize }]
         .iter()
         .find(|c| c.enabled && (tag == ComponentTag::None || c.tags.get(tag as u16)))
@@ -1540,7 +1564,7 @@ impl EntityManager {
         &self,
         tag: ComponentTag,
     ) -> eyre::Result<C> {
-        if self.bypass_cache {
+        if self.manager.bypass_cache {
             return self.entity().get_first_component_including_disabled::<C>(
                 if matches!(tag, ComponentTag::None) {
                     None
@@ -1549,7 +1573,7 @@ impl EntityManager {
                 },
             );
         }
-        if let Some(coms) = self.current_data.components
+        if let Some(coms) = self.manager.current_data.components
             [const { CachedComponent::from_component::<C>() as usize }]
         .iter()
         .find(|c| tag == ComponentTag::None || c.tags.get(tag as u16))
@@ -1563,7 +1587,7 @@ impl EntityManager {
         &mut self,
         tags: ComponentTag,
     ) -> eyre::Result<bool> {
-        if self.bypass_cache {
+        if self.manager.bypass_cache {
             return self.entity().remove_all_components_of_type::<C>(
                 if matches!(tags, ComponentTag::None) {
                     None
@@ -1575,13 +1599,13 @@ impl EntityManager {
         let idx = const { CachedComponent::from_component::<C>() as usize };
         let mut is_some = false;
         let mut err = None;
-        let vec = std::mem::take(&mut self.current_data.components[idx]);
+        let vec = std::mem::take(&mut self.manager.current_data.components[idx]);
         for com in vec.into_iter() {
             // Once a removal has failed, stop removing but keep every entry:
             // the components are still on the entity, and dropping them from
             // the snapshot only makes the cache lie about a smaller entity.
             if err.is_none() && (tags == ComponentTag::None || com.tags.get(tags as u16)) {
-                match self.current_entity.remove_component(com.id) {
+                match self.manager.current_entity.remove_component(com.id) {
                     Ok(()) => {
                         is_some = true;
                         continue;
@@ -1589,7 +1613,7 @@ impl EntityManager {
                     Err(e) => err = Some(e),
                 }
             }
-            self.current_data.components[idx].push(com);
+            self.manager.current_data.components[idx].push(com);
         }
         match err {
             Some(e) => Err(e),
@@ -1599,8 +1623,8 @@ impl EntityManager {
     pub fn iter_all_components_of_type<C: Component>(
         &self,
         tag: ComponentTag,
-    ) -> impl Iterator<Item = C> {
-        if self.bypass_cache {
+    ) -> impl Iterator<Item = C> + use<C> {
+        if self.manager.bypass_cache {
             return self
                 .entity()
                 .iter_all_components_of_type::<C>(if matches!(tag, ComponentTag::None) {
@@ -1612,7 +1636,7 @@ impl EntityManager {
                 .unwrap_or_default()
                 .into_iter();
         }
-        self.current_data.components[const { CachedComponent::from_component::<C>() as usize }]
+        self.manager.current_data.components[const { CachedComponent::from_component::<C>() as usize }]
             .iter()
             .filter(move |c| c.enabled && (tag == ComponentTag::None || c.tags.get(tag as u16)))
             .map(|c| C::from(c.id))
@@ -1622,15 +1646,15 @@ impl EntityManager {
     fn iter_mut_all_components_of_type<C: Component>(
         &mut self,
     ) -> impl Iterator<Item = &mut ComponentData> {
-        self.current_data.components[const { CachedComponent::from_component::<C>() as usize }]
+        self.manager.current_data.components[const { CachedComponent::from_component::<C>() as usize }]
             .iter_mut()
             .filter(|c| c.enabled)
     }
     pub fn iter_all_components_of_type_including_disabled<C: Component>(
         &self,
         tag: ComponentTag,
-    ) -> impl Iterator<Item = C> {
-        if self.bypass_cache {
+    ) -> impl Iterator<Item = C> + use<C> {
+        if self.manager.bypass_cache {
             return self
                 .entity()
                 .iter_all_components_of_type_including_disabled::<C>(
@@ -1644,7 +1668,7 @@ impl EntityManager {
                 .unwrap_or_default()
                 .into_iter();
         }
-        self.current_data.components[const { CachedComponent::from_component::<C>() as usize }]
+        self.manager.current_data.components[const { CachedComponent::from_component::<C>() as usize }]
             .iter()
             .filter(move |c| tag == ComponentTag::None || c.tags.get(tag as u16))
             .map(|c| C::from(c.id))
@@ -1654,15 +1678,15 @@ impl EntityManager {
     fn iter_all_components_of_type_including_disabled_raw<C: Component>(
         &self,
     ) -> impl Iterator<Item = &ComponentData> {
-        self.current_data.components[const { CachedComponent::from_component::<C>() as usize }]
+        self.manager.current_data.components[const { CachedComponent::from_component::<C>() as usize }]
             .iter()
     }
     pub fn add_component<C: Component>(&mut self) -> eyre::Result<C> {
-        if self.bypass_cache {
+        if self.manager.bypass_cache {
             return self.entity().add_component();
         }
-        let c = self.current_entity.add_component::<C>()?;
-        self.current_data.components[const { CachedComponent::from_component::<C>() as usize }]
+        let c = self.manager.current_entity.add_component::<C>()?;
+        self.manager.current_data.components[const { CachedComponent::from_component::<C>() as usize }]
             .push(ComponentData::new(
                 *c,
                 C::NAME_STR == "VariableStorageComponent",
@@ -1670,13 +1694,13 @@ impl EntityManager {
         Ok(c)
     }
     fn add_component_var<C: Component>(&mut self, name: VarName) -> eyre::Result<C> {
-        let c = self.current_entity.add_component::<C>()?;
-        self.current_data.components[const { CachedComponent::from_component::<C>() as usize }]
+        let c = self.manager.current_entity.add_component::<C>()?;
+        self.manager.current_data.components[const { CachedComponent::from_component::<C>() as usize }]
             .push(ComponentData::new_with_name(*c, name));
         Ok(c)
     }
     pub fn get_var(&self, name: VarName) -> Option<VariableStorageComponent> {
-        if self.bypass_cache {
+        if self.manager.bypass_cache {
             return self.entity().get_var(name.to_str());
         }
         let mut i =
@@ -1690,7 +1714,7 @@ impl EntityManager {
         })
     }
     pub fn get_var_unknown(&self, name: &str) -> Option<VariableStorageComponent> {
-        if self.bypass_cache {
+        if self.manager.bypass_cache {
             return self.entity().get_var(name);
         }
         let mut i =
@@ -1709,7 +1733,7 @@ impl EntityManager {
         })
     }
     pub fn get_var_or_default(&mut self, name: VarName) -> eyre::Result<VariableStorageComponent> {
-        if self.bypass_cache {
+        if self.manager.bypass_cache {
             return self.entity().get_var_or_default(name.to_str());
         }
         if let Some(var) = self.get_var(name) {
@@ -1724,7 +1748,7 @@ impl EntityManager {
         &mut self,
         name: &str,
     ) -> eyre::Result<VariableStorageComponent> {
-        if self.bypass_cache {
+        if self.manager.bypass_cache {
             return self.entity().get_var_or_default(name);
         }
         if let Some(var) = self.get_var_unknown(name) {
@@ -1736,15 +1760,18 @@ impl EntityManager {
         }
     }
     pub fn add_lua_init_component<C: Component>(&mut self, file: &str) -> eyre::Result<C> {
-        if self.bypass_cache {
+        if self.manager.bypass_cache {
             return self.entity().add_lua_init_component(file);
         }
-        let c = self.current_entity.add_lua_init_component::<C>(file)?;
-        self.current_data.components[const { CachedComponent::from_component::<C>() as usize }]
+        let c = self
+            .manager
+            .current_entity
+            .add_lua_init_component::<C>(file)?;
+        self.manager.current_data.components[const { CachedComponent::from_component::<C>() as usize }]
             .push(ComponentData::new(*c, false));
         Ok(c)
     }
-    /// Tags a component of the current entity, keeping the snapshot in step.
+    /// Tags a component of this entity, keeping the snapshot in step.
     ///
     /// Tagging through the raw `ComponentID` instead leaves the snapshot's tag
     /// bitset as it was when the component was added - empty, for one added
@@ -1756,11 +1783,11 @@ impl EntityManager {
         tag: ComponentTag,
     ) -> eyre::Result<()> {
         com.add_tag(tag.to_str())?;
-        if self.bypass_cache {
+        if self.manager.bypass_cache {
             return Ok(());
         }
         let id = *com;
-        if let Some(c) = self.current_data.components
+        if let Some(c) = self.manager.current_data.components
             [const { CachedComponent::from_component::<C>() as usize }]
         .iter_mut()
         .find(|c| c.id == id)
@@ -1769,7 +1796,7 @@ impl EntityManager {
         }
         Ok(())
     }
-    /// Adds a named `VariableStorageComponent` to the current entity, keeping the
+    /// Adds a named `VariableStorageComponent` to this entity, keeping the
     /// snapshot in step.
     ///
     /// Naming it through the raw `ComponentID` afterwards instead leaves the
@@ -1784,7 +1811,7 @@ impl EntityManager {
         &mut self,
         name: VarName,
     ) -> eyre::Result<VariableStorageComponent> {
-        let var = if self.bypass_cache {
+        let var = if self.manager.bypass_cache {
             self.entity().add_component::<VariableStorageComponent>()?
         } else {
             self.add_component_var::<VariableStorageComponent>(name)?
@@ -1797,12 +1824,12 @@ impl EntityManager {
         tag: ComponentTag,
         enabled: bool,
     ) -> eyre::Result<()> {
-        if self.bypass_cache {
+        if self.manager.bypass_cache {
             return self
                 .entity()
                 .set_components_with_tag_enabled(tag.to_str().into(), enabled);
         }
-        for c in self.current_data.components.iter_mut().flatten() {
+        for c in self.manager.current_data.components.iter_mut().flatten() {
             if c.tags.get(tag as u16) {
                 c.enabled = enabled
             }
@@ -1811,7 +1838,8 @@ impl EntityManager {
         // component. Only 32 component types are cached at all, so "the
         // snapshot has none" is the normal case for most tags, and gating on it
         // turned this into a silent no-op that still returned Ok.
-        self.current_entity
+        self.manager
+            .current_entity
             .set_components_with_tag_enabled(tag.to_str().into(), enabled)
     }
     pub fn set_component_enabled<C: Component>(
@@ -1819,38 +1847,41 @@ impl EntityManager {
         com: C,
         enabled: bool,
     ) -> eyre::Result<()> {
-        if self.bypass_cache {
+        if self.manager.bypass_cache {
             return self.entity().set_component_enabled(*com, enabled);
         }
         let id = *com;
-        if let Some(n) = self.current_data.components
+        if let Some(n) = self.manager.current_data.components
             [const { CachedComponent::from_component::<C>() as usize }]
         .iter_mut()
         .find(|c| c.id == id)
             && n.enabled != enabled
         {
             n.enabled = enabled;
-            self.current_entity.set_component_enabled(id, enabled)?;
+            self.manager
+                .current_entity
+                .set_component_enabled(id, enabled)?;
         }
         Ok(())
     }
     pub fn remove_component<C: Component>(&mut self, component: C) -> eyre::Result<()> {
-        if self.bypass_cache {
+        if self.manager.bypass_cache {
             return self.entity().remove_component(*component);
         }
         let id = *component;
-        if let Some(n) = self.current_data.components
+        if let Some(n) = self.manager.current_data.components
             [const { CachedComponent::from_component::<C>() as usize }]
         .iter()
         .position(|c| c.id == id)
         {
-            self.current_data.components[const { CachedComponent::from_component::<C>() as usize }]
-                .remove(n);
+            self.manager.current_data.components
+                [const { CachedComponent::from_component::<C>() as usize }]
+            .remove(n);
         }
-        self.current_entity.remove_component(id)
+        self.manager.current_entity.remove_component(id)
     }
     pub fn get_current_stains(&self) -> eyre::Result<u64> {
-        if self.bypass_cache {
+        if self.manager.bypass_cache {
             return self.entity().get_current_stains();
         }
         let mut current = 0;
@@ -1866,7 +1897,7 @@ impl EntityManager {
         Ok(current)
     }
     pub fn set_current_stains(&self, current_stains: u64) -> eyre::Result<()> {
-        if self.bypass_cache {
+        if self.manager.bypass_cache {
             return self.entity().set_current_stains(current_stains);
         }
         if let Some(status) =
@@ -1874,7 +1905,7 @@ impl EntityManager {
         {
             for ((i, v), id) in status.stain_effects()?.enumerate().zip(TO_ID.iter()) {
                 if v >= 0.15 && current_stains & (1 << i) == 0 {
-                    self.current_entity.remove_stain(id)?
+                    self.manager.current_entity.remove_stain(id)?
                 }
             }
         }

--- a/noita_api/src/lib.rs
+++ b/noita_api/src/lib.rs
@@ -1273,7 +1273,7 @@ pub struct EntityManager {
     pub files: Option<FxHashMap<Cow<'static, str>, Vec<String>>>,
     frame_num: i32,
     camera_pos: (f64, f64),
-    use_cache: bool,
+    bypass_cache: bool,
 }
 impl Default for EntityManager {
     fn default() -> Self {
@@ -1285,7 +1285,7 @@ impl Default for EntityManager {
             files: Some(FxHashMap::with_capacity_and_hasher(512, FxBuildHasher)),
             frame_num: -1,
             camera_pos: (0.0, 0.0),
-            use_cache: false,
+            bypass_cache: false,
         }
     }
 }
@@ -1343,10 +1343,14 @@ impl EntityData {
     }
 }
 impl EntityManager {
-    pub fn set_cache(&mut self, cache: bool) {
+    /// When set, every accessor skips `current_data` and issues a fresh Lua
+    /// call instead. This is the slow, always-correct path - an escape hatch for
+    /// debugging cache staleness, not an optimization. The field used to be
+    /// called `use_cache`, which read exactly backwards at all ~25 call sites.
+    pub fn set_bypass_cache(&mut self, bypass: bool) {
         self.cache.clear();
         self.has_ran = false;
-        self.use_cache = cache;
+        self.bypass_cache = bypass;
     }
     pub fn init_frame_num(&mut self) -> eyre::Result<()> {
         if self.frame_num == -1 {
@@ -1367,7 +1371,7 @@ impl EntityManager {
         self.camera_pos
     }
     pub fn set_current_entity(&mut self, ent: EntityID) -> eyre::Result<()> {
-        if self.use_cache {
+        if self.bypass_cache {
             self.current_entity = ent;
             return Ok(());
         }
@@ -1398,7 +1402,7 @@ impl EntityManager {
         self.has_ran = false;
     }
     pub fn remove_ent(&mut self, ent: &EntityID) {
-        if &self.current_entity == ent || self.use_cache {
+        if &self.current_entity == ent || self.bypass_cache {
             self.has_ran = false;
         } else {
             self.cache.remove(ent);
@@ -1406,28 +1410,28 @@ impl EntityManager {
     }
     pub fn add_tag(&mut self, tag: CachedTag) -> eyre::Result<()> {
         self.current_entity.add_tag(tag.to_tag())?;
-        if self.use_cache {
+        if self.bypass_cache {
             return Ok(());
         }
         self.current_data.add_tag(tag);
         Ok(())
     }
     pub fn has_tag(&self, tag: CachedTag) -> bool {
-        if self.use_cache {
+        if self.bypass_cache {
             return self.entity().has_tag(tag.to_tag());
         }
         self.current_data.has_tag(tag)
     }
     pub fn remove_tag(&mut self, tag: CachedTag) -> eyre::Result<()> {
         self.current_entity.remove_tag(tag.to_tag())?;
-        if self.use_cache {
+        if self.bypass_cache {
             return Ok(());
         }
         self.current_data.remove_tag(tag);
         Ok(())
     }
     pub fn check_all_phys_init(&mut self) -> eyre::Result<bool> {
-        if self.use_cache {
+        if self.bypass_cache {
             return self.entity().check_all_phys_init();
         }
         if self.current_data.phys_init {
@@ -1442,7 +1446,7 @@ impl EntityManager {
         Ok(true)
     }
     pub fn try_get_first_component<C: Component>(&self, tag: ComponentTag) -> Option<C> {
-        if self.use_cache {
+        if self.bypass_cache {
             return self
                 .entity()
                 .try_get_first_component::<C>(if matches!(tag, ComponentTag::None) {
@@ -1461,7 +1465,7 @@ impl EntityManager {
         &self,
         tag: ComponentTag,
     ) -> Option<C> {
-        if self.use_cache {
+        if self.bypass_cache {
             return self
                 .entity()
                 .try_get_first_component_including_disabled::<C>(
@@ -1479,7 +1483,7 @@ impl EntityManager {
             .map(|c| C::from(c.id))
     }
     pub fn get_first_component<C: Component>(&self, tag: ComponentTag) -> eyre::Result<C> {
-        if self.use_cache {
+        if self.bypass_cache {
             return self
                 .entity()
                 .get_first_component::<C>(if matches!(tag, ComponentTag::None) {
@@ -1503,7 +1507,7 @@ impl EntityManager {
         &self,
         tag: ComponentTag,
     ) -> eyre::Result<C> {
-        if self.use_cache {
+        if self.bypass_cache {
             return self.entity().get_first_component_including_disabled::<C>(
                 if matches!(tag, ComponentTag::None) {
                     None
@@ -1526,7 +1530,7 @@ impl EntityManager {
         &mut self,
         tags: ComponentTag,
     ) -> eyre::Result<bool> {
-        if self.use_cache {
+        if self.bypass_cache {
             return self.entity().remove_all_components_of_type::<C>(
                 if matches!(tags, ComponentTag::None) {
                     None
@@ -1554,7 +1558,7 @@ impl EntityManager {
         &self,
         tag: ComponentTag,
     ) -> impl Iterator<Item = C> {
-        if self.use_cache {
+        if self.bypass_cache {
             return self
                 .entity()
                 .iter_all_components_of_type::<C>(if matches!(tag, ComponentTag::None) {
@@ -1584,7 +1588,7 @@ impl EntityManager {
         &self,
         tag: ComponentTag,
     ) -> impl Iterator<Item = C> {
-        if self.use_cache {
+        if self.bypass_cache {
             return self
                 .entity()
                 .iter_all_components_of_type_including_disabled::<C>(
@@ -1612,7 +1616,7 @@ impl EntityManager {
             .iter()
     }
     pub fn add_component<C: Component>(&mut self) -> eyre::Result<C> {
-        if self.use_cache {
+        if self.bypass_cache {
             return self.entity().add_component();
         }
         let c = self.current_entity.add_component::<C>()?;
@@ -1630,7 +1634,7 @@ impl EntityManager {
         Ok(c)
     }
     pub fn get_var(&self, name: VarName) -> Option<VariableStorageComponent> {
-        if self.use_cache {
+        if self.bypass_cache {
             return self.entity().get_var(name.to_str());
         }
         let mut i =
@@ -1644,7 +1648,7 @@ impl EntityManager {
         })
     }
     pub fn get_var_unknown(&self, name: &str) -> Option<VariableStorageComponent> {
-        if self.use_cache {
+        if self.bypass_cache {
             return self.entity().get_var(name);
         }
         let mut i =
@@ -1663,7 +1667,7 @@ impl EntityManager {
         })
     }
     pub fn get_var_or_default(&mut self, name: VarName) -> eyre::Result<VariableStorageComponent> {
-        if self.use_cache {
+        if self.bypass_cache {
             return self.entity().get_var_or_default(name.to_str());
         }
         if let Some(var) = self.get_var(name) {
@@ -1678,7 +1682,7 @@ impl EntityManager {
         &mut self,
         name: &str,
     ) -> eyre::Result<VariableStorageComponent> {
-        if self.use_cache {
+        if self.bypass_cache {
             return self.entity().get_var_or_default(name);
         }
         if let Some(var) = self.get_var_unknown(name) {
@@ -1690,7 +1694,7 @@ impl EntityManager {
         }
     }
     pub fn add_lua_init_component<C: Component>(&mut self, file: &str) -> eyre::Result<C> {
-        if self.use_cache {
+        if self.bypass_cache {
             return self.entity().add_lua_init_component(file);
         }
         let c = self.current_entity.add_lua_init_component::<C>(file)?;
@@ -1703,7 +1707,7 @@ impl EntityManager {
         tag: ComponentTag,
         enabled: bool,
     ) -> eyre::Result<()> {
-        if self.use_cache {
+        if self.bypass_cache {
             return self
                 .entity()
                 .set_components_with_tag_enabled(tag.to_str().into(), enabled);
@@ -1726,7 +1730,7 @@ impl EntityManager {
         com: C,
         enabled: bool,
     ) -> eyre::Result<()> {
-        if self.use_cache {
+        if self.bypass_cache {
             return self.entity().set_component_enabled(*com, enabled);
         }
         let id = *com;
@@ -1742,7 +1746,7 @@ impl EntityManager {
         Ok(())
     }
     pub fn remove_component<C: Component>(&mut self, component: C) -> eyre::Result<()> {
-        if self.use_cache {
+        if self.bypass_cache {
             return self.entity().remove_component(*component);
         }
         let id = *component;
@@ -1757,7 +1761,7 @@ impl EntityManager {
         self.current_entity.remove_component(id)
     }
     pub fn get_current_stains(&self) -> eyre::Result<u64> {
-        if self.use_cache {
+        if self.bypass_cache {
             return self.entity().get_current_stains();
         }
         let mut current = 0;
@@ -1773,7 +1777,7 @@ impl EntityManager {
         Ok(current)
     }
     pub fn set_current_stains(&self, current_stains: u64) -> eyre::Result<()> {
-        if self.use_cache {
+        if self.bypass_cache {
             return self.entity().set_current_stains(current_stains);
         }
         if let Some(status) =

--- a/noita_api/src/lib.rs
+++ b/noita_api/src/lib.rs
@@ -1289,7 +1289,6 @@ pub struct EntityManager {
     current_entity: EntityID,
     current_data: EntityData,
     has_ran: bool,
-    pub files: Option<FxHashMap<Cow<'static, str>, Vec<String>>>,
     frame_num: i32,
     camera_pos: (f64, f64),
     bypass_cache: bool,
@@ -1301,7 +1300,6 @@ impl Default for EntityManager {
             current_entity: EntityID(NonZeroIsize::new(-1).unwrap()),
             current_data: Default::default(),
             has_ran: false,
-            files: Some(FxHashMap::with_capacity_and_hasher(512, FxBuildHasher)),
             frame_num: -1,
             camera_pos: (0.0, 0.0),
             bypass_cache: false,
@@ -1881,20 +1879,5 @@ impl EntityManager {
             }
         }
         Ok(())
-    }
-}
-pub fn get_file<'a>(
-    files: &'a mut Option<FxHashMap<Cow<'static, str>, Vec<String>>>,
-    file: Cow<'static, str>,
-) -> eyre::Result<&'a [String]> {
-    match files.as_mut().unwrap().entry(file) {
-        std::collections::hash_map::Entry::Occupied(entry) => Ok(entry.into_mut()),
-        std::collections::hash_map::Entry::Vacant(entry) => {
-            let content = raw::mod_text_file_get_content(entry.key().clone())?;
-            let mut split = content.split("name=\"");
-            split.next();
-            let split = split.map(|piece| piece.split_once("\"").unwrap().0.to_string());
-            Ok(entry.insert(split.collect::<Vec<String>>()))
-        }
     }
 }

--- a/noita_proxy/src/net/world/world_model.rs
+++ b/noita_proxy/src/net/world/world_model.rs
@@ -142,14 +142,6 @@ impl WorldModel {
         self.updated_chunks.insert(chunk_coord);
     }*/
 
-    fn get_pixel(&self, x: i32, y: i32) -> Pixel {
-        let (chunk_coord, offset) = Self::get_chunk_coords(x, y);
-        self.chunks
-            .get(&chunk_coord)
-            .map(|chunk| chunk.pixel(offset))
-            .unwrap_or_default()
-    }
-
     pub fn apply_noita_update(
         &mut self,
         update: &NoitaWorldUpdate,
@@ -176,6 +168,10 @@ impl WorldModel {
         let mut written: i64 = 0;
         let (mut chunk_coord, _) = Self::get_chunk_coords(header.x, header.y);
         let mut chunk = self.chunks.entry(chunk_coord).or_default();
+        // Both sets below are keyed by chunk, so touching them per pixel was
+        // 2-3 hash operations per changed pixel. Accumulate and flush on chunk
+        // transition instead.
+        let mut chunk_dirty = false;
         'outer: for run in runs {
             let flags = if run.data.flags > 0 {
                 PixelFlags::Fluid
@@ -191,6 +187,11 @@ impl WorldModel {
                 let ys = header.y + y;
                 let (new_chunk_coord, offset) = Self::get_chunk_coords(xs, ys);
                 if chunk_coord != new_chunk_coord {
+                    if chunk_dirty {
+                        self.updated_chunks.insert(chunk_coord);
+                        changed.remove(&chunk_coord);
+                        chunk_dirty = false;
+                    }
                     chunk_coord = new_chunk_coord;
                     chunk = self.chunks.entry(chunk_coord).or_default();
                 }
@@ -202,10 +203,7 @@ impl WorldModel {
                     chunk,
                     offset,
                 ) {
-                    self.updated_chunks.insert(chunk_coord);
-                    if changed.contains(&chunk_coord) {
-                        changed.remove(&chunk_coord);
-                    }
+                    chunk_dirty = true;
                 }
                 x += 1;
                 if x == i32::from(header.w) + 1 {
@@ -214,30 +212,41 @@ impl WorldModel {
                 }
             }
         }
+        if chunk_dirty {
+            self.updated_chunks.insert(chunk_coord);
+            changed.remove(&chunk_coord);
+        }
     }
 
-    pub fn get_noita_update(&self, x: i32, y: i32, w: u32, h: u32) -> NoitaWorldUpdate {
-        assert!(w <= 256);
-        assert!(h <= 256);
+    /// Serialize one whole chunk. Callers always want chunk-aligned,
+    /// CHUNK_SIZE-square regions, so this indexes the chunk directly instead of
+    /// going through a hash lookup per pixel.
+    fn get_chunk_noita_update(&self, chunk_coord: ChunkCoord) -> NoitaWorldUpdate {
+        let x = chunk_coord.0 * (CHUNK_SIZE as i32);
+        let y = chunk_coord.1 * (CHUNK_SIZE as i32);
         let mut runner = PixelRunner::new();
-        for j in 0..(h as i32) {
-            for i in 0..(w as i32) {
-                runner.put_pixel(self.get_pixel(x + i, y + j).to_raw())
+        match self.chunks.get(&chunk_coord) {
+            // Offsets are laid out as `x + y * CHUNK_SIZE`, so a linear walk
+            // visits pixels in the same order as the old row-major loop.
+            Some(chunk) => {
+                for offset in 0..(CHUNK_SIZE * CHUNK_SIZE) {
+                    runner.put_pixel(chunk.pixel(offset).to_raw())
+                }
+            }
+            None => {
+                let unknown = Pixel::default().to_raw();
+                for _ in 0..(CHUNK_SIZE * CHUNK_SIZE) {
+                    runner.put_pixel(unknown)
+                }
             }
         }
-        runner.into_noita_update(x, y, (w - 1) as u8, (h - 1) as u8)
+        runner.into_noita_update(x, y, (CHUNK_SIZE - 1) as u8, (CHUNK_SIZE - 1) as u8)
     }
 
     pub fn get_all_noita_updates(&self) -> Vec<Vec<u8>> {
         let mut updates = Vec::new();
         for chunk_coord in &self.updated_chunks {
-            let update = self.get_noita_update(
-                chunk_coord.0 * (CHUNK_SIZE as i32),
-                chunk_coord.1 * (CHUNK_SIZE as i32),
-                CHUNK_SIZE as u32,
-                CHUNK_SIZE as u32,
-            );
-            updates.push(update.save());
+            updates.push(self.get_chunk_noita_update(*chunk_coord).save());
         }
         updates
     }

--- a/noita_proxy/src/net/world/world_model/chunk.rs
+++ b/noita_proxy/src/net/world/world_model/chunk.rs
@@ -1,7 +1,6 @@
 use std::num::NonZeroU16;
 
 use bitcode::{Decode, Encode};
-use crossbeam::atomic::AtomicCell;
 
 use super::{
     CHUNK_SIZE, ChunkData,
@@ -105,9 +104,12 @@ impl Default for CompactPixel {
 
 pub struct Chunk {
     pixels: [u16; CHUNK_SQUARE],
+    // A plain bool array, deliberately, even though a bitset would be 2 KiB
+    // instead of 16 KiB. get/set run per pixel, while the size only matters on
+    // rehash and clone, and the u128 bitset measures ~6x slower on exactly this
+    // access pattern - see test_changed below, and commit 71c934d3 which made
+    // this same call the first time.
     changed: Changed<bool, CHUNK_SQUARE>,
-    any_changed: bool,
-    crc: AtomicCell<Option<u64>>,
 }
 
 struct Changed<T: Default, const N: usize>([T; N]);
@@ -187,8 +189,6 @@ impl Default for Chunk {
         Self {
             pixels: [4095; CHUNK_SQUARE],
             changed: Changed([false; CHUNK_SQUARE]),
-            any_changed: false,
-            crc: None.into(),
         }
     }
 }
@@ -223,14 +223,15 @@ impl Chunk {
     }
 
     pub fn mark_changed(&mut self, offset: usize) {
+        // This used to also store to a `crc: AtomicCell<Option<u64>>`, which is
+        // 16 bytes and therefore *not* lock-free - every changed pixel took a
+        // lock in crossbeam's process-global seqlock table, contended across the
+        // rayon terraforming workers. The field was never read.
         self.changed.set(offset);
-        self.any_changed = true;
-        self.crc.store(None);
     }
 
     pub fn clear_changed(&mut self) {
         self.changed = Changed([false; CHUNK_SQUARE]);
-        self.any_changed = false;
     }
 
     pub fn to_chunk_data(&self) -> ChunkData {

--- a/quant.ew/files/core/player_fns.lua
+++ b/quant.ew/files/core/player_fns.lua
@@ -382,6 +382,9 @@ local player_fns = {
             -- player_fns.set_projectile_seed.
             projectile_seed_order = {},
             projectile_seed_tail = 1,
+            -- Keys held outside the ring and never evicted; see
+            -- player_fns.set_projectile_seed.
+            projectile_seed_anchors = {},
             currently_polymorphed = false,
             mouse_x = 0,
             pos_x = 0,
@@ -398,12 +401,29 @@ local player_fns = {
 -- projectile_seed_chain is keyed by entity id, and Noita never reuses entity
 -- ids, so writing to it unconditionally leaked ~3 entries per projectile fired
 -- for the whole session (unbounded memory, growing GC cost, and a rehash pause
--- at every doubling). Only the recently-fired projectiles are ever read back,
--- so bound it with an insertion-order ring and evict the oldest.
+-- at every doubling). Per-projectile keys are read back only while the chain
+-- they belong to is still firing, so bound those with an insertion-order ring
+-- and evict the oldest.
+--
+-- Anchor keys are the exception: OnProjectileFired re-reads `shooter_id - 1`,
+-- key 0 and the world-state entity on *every* shot, for the whole session, so
+-- evicting one silently resets that player's seed chain to 25 and desyncs the
+-- shot. There are at most a handful per player, so they are held out of the
+-- ring and never evicted. Callers mark them via the `anchor` argument.
 local SEED_CHAIN_MAX = 4096
 
-function player_fns.set_projectile_seed(player_data, key, rng)
+function player_fns.set_projectile_seed(player_data, key, rng, anchor)
     local chain = player_data.projectile_seed_chain
+    local anchors = player_data.projectile_seed_anchors
+    if anchors == nil then
+        anchors = {}
+        player_data.projectile_seed_anchors = anchors
+    end
+    if anchor then
+        anchors[key] = true
+        chain[key] = rng
+        return
+    end
     if chain[key] == nil then
         local order = player_data.projectile_seed_order
         local tail = player_data.projectile_seed_tail
@@ -413,7 +433,9 @@ function player_fns.set_projectile_seed(player_data, key, rng)
             player_data.projectile_seed_order = order
         end
         local evicted = order[tail]
-        if evicted ~= nil then
+        -- A key can be promoted to an anchor after it took a ring slot; leave
+        -- the value alone in that case and just reuse the slot.
+        if evicted ~= nil and not anchors[evicted] then
             chain[evicted] = nil
         end
         order[tail] = key

--- a/quant.ew/files/core/player_fns.lua
+++ b/quant.ew/files/core/player_fns.lua
@@ -377,7 +377,11 @@ local player_fns = {
             name = "[Peer " .. peer_id .. "]",
             controls = {},
             projectile_rng_init = {},
-            projectile_seed_chain = {}, -- TODO clean
+            projectile_seed_chain = {},
+            -- Insertion-order ring used to bound projectile_seed_chain; see
+            -- player_fns.set_projectile_seed.
+            projectile_seed_order = {},
+            projectile_seed_tail = 1,
             currently_polymorphed = false,
             mouse_x = 0,
             pos_x = 0,
@@ -390,6 +394,33 @@ local player_fns = {
         }
     end,
 }
+
+-- projectile_seed_chain is keyed by entity id, and Noita never reuses entity
+-- ids, so writing to it unconditionally leaked ~3 entries per projectile fired
+-- for the whole session (unbounded memory, growing GC cost, and a rehash pause
+-- at every doubling). Only the recently-fired projectiles are ever read back,
+-- so bound it with an insertion-order ring and evict the oldest.
+local SEED_CHAIN_MAX = 4096
+
+function player_fns.set_projectile_seed(player_data, key, rng)
+    local chain = player_data.projectile_seed_chain
+    if chain[key] == nil then
+        local order = player_data.projectile_seed_order
+        local tail = player_data.projectile_seed_tail
+        if order == nil then
+            order = {}
+            tail = 1
+            player_data.projectile_seed_order = order
+        end
+        local evicted = order[tail]
+        if evicted ~= nil then
+            chain[evicted] = nil
+        end
+        order[tail] = key
+        player_data.projectile_seed_tail = (tail % SEED_CHAIN_MAX) + 1
+    end
+    chain[key] = rng
+end
 
 function player_fns.serialize_position(player_data)
     local entity = player_data.entity

--- a/quant.ew/files/core/util.lua
+++ b/quant.ew/files/core/util.lua
@@ -188,7 +188,7 @@ end
 -- Caches function's results by first argument
 function util.cached_fn(fn)
     local cache = {}
-    function cached(arg, ...)
+    local function cached(arg, ...)
         if cache[arg] ~= nil then
             return cache[arg]
         end

--- a/quant.ew/files/system/ewext_init/ewext_init.lua
+++ b/quant.ew/files/system/ewext_init/ewext_init.lua
@@ -9,7 +9,7 @@ local module = {}
 
 local log = false
 
-local cache = false
+local bypass_cache = false
 
 -- Used in ewext
 EwextSerialize = util.serialize_entity
@@ -35,8 +35,8 @@ function module.on_world_initialized()
     ewext.module_on_world_init()
     log = ModSettingGet("quant.ew.log_performance") or false
     ewext.set_log(log)
-    cache = ModSettingGet("quant.ew.cache") or false
-    ewext.set_cache(cache)
+    bypass_cache = ModSettingGet("quant.ew.cache") or false
+    ewext.set_bypass_cache(bypass_cache)
 end
 
 local function oh_another_world_state(entity)
@@ -94,9 +94,9 @@ function module.on_world_update()
         ewext.set_log(log)
     end
     local temp = ModSettingGet("quant.ew.cache") or false
-    if temp ~= cache then
-        cache = temp
-        ewext.set_cache(cache)
+    if temp ~= bypass_cache then
+        bypass_cache = temp
+        ewext.set_bypass_cache(bypass_cache)
     end
     if GameGetWorldStateEntity() ~= initial_world_state_entity then
         oh_another_world_state(GameGetWorldStateEntity())

--- a/quant.ew/files/system/ewext_init/ewext_init.lua
+++ b/quant.ew/files/system/ewext_init/ewext_init.lua
@@ -88,15 +88,19 @@ function module.on_draw_debug_window(imgui)
 end
 
 function module.on_world_update()
-    local temp = ModSettingGet("quant.ew.log_performance") or false
-    if temp ~= log then
-        log = temp
-        ewext.set_log(log)
-    end
-    local temp = ModSettingGet("quant.ew.cache") or false
-    if temp ~= bypass_cache then
-        bypass_cache = temp
-        ewext.set_bypass_cache(bypass_cache)
+    -- These only change when the player is in the settings menu; polling them
+    -- every frame is a string-keyed engine lookup per setting per frame.
+    if GameGetFrameNum() % 60 == 0 then
+        local temp = ModSettingGet("quant.ew.log_performance") or false
+        if temp ~= log then
+            log = temp
+            ewext.set_log(log)
+        end
+        temp = ModSettingGet("quant.ew.cache") or false
+        if temp ~= bypass_cache then
+            bypass_cache = temp
+            ewext.set_bypass_cache(bypass_cache)
+        end
     end
     if GameGetWorldStateEntity() ~= initial_world_state_entity then
         oh_another_world_state(GameGetWorldStateEntity())

--- a/quant.ew/files/system/homunculus/homunculus.lua
+++ b/quant.ew/files/system/homunculus/homunculus.lua
@@ -43,6 +43,17 @@ local function get_lukki(entity)
     return alive
 end
 
+-- Register a locally-spawned minion in the cache straight away. Without this
+-- the receiver below re-derives `#l` from a list that is up to
+-- LUKKI_RESCAN_INTERVAL frames stale, so every message that arrives before the
+-- next rescan spawns `#lu - #l` minions again.
+local function add_lukki(entity, child)
+    local cached = lukki_cache[entity]
+    if cached ~= nil then
+        table.insert(cached.list, child)
+    end
+end
+
 local function get_entities(entity)
     local homunculy = {}
     local ghost = {}
@@ -95,6 +106,7 @@ function rpc.send_positions(ho, lu, gh, f)
             EntityRemoveComponent(n, EntityGetFirstComponent(n, "LuaComponent"))
             EntityAddTag(n, "perk_entity")
             util.make_ephemerial(n)
+            add_lukki(ctx.rpc_player_data.entity, n)
         end
     end
     if #gh ~= 0 then

--- a/quant.ew/files/system/homunculus/homunculus.lua
+++ b/quant.ew/files/system/homunculus/homunculus.lua
@@ -1,5 +1,48 @@
 local rpc = net.new_rpc_namespace()
 local homunculus = {}
+
+-- EntityGetWithTag("lukki") is an engine-wide scan. It used to run once per
+-- frame per player, including for players who never took the perk. Lukki perk
+-- entities are created/destroyed rarely, so the owning scan is cached per
+-- player entity and refreshed periodically; positions are still read every
+-- frame off the cached list.
+local LUKKI_RESCAN_INTERVAL = 20
+local lukki_cache = {}
+
+local function get_lukki(entity)
+    local frame = GameGetFrameNum()
+    local cached = lukki_cache[entity]
+    if cached == nil or frame - cached.frame >= LUKKI_RESCAN_INTERVAL then
+        -- Drop entries for players that no longer exist so this can't grow.
+        for ent, _ in pairs(lukki_cache) do
+            if not EntityGetIsAlive(ent) then
+                lukki_cache[ent] = nil
+            end
+        end
+        local found = {}
+        for _, child in ipairs(EntityGetWithTag("lukki") or {}) do
+            if EntityHasTag(child, "perk_entity") then
+                -- EntityGetComponent returns nil (not an empty table) when the
+                -- entity has no such component.
+                local comps = EntityGetComponent(child, "VariableStorageComponent")
+                local var = comps ~= nil and comps[2] or nil
+                if var ~= nil and ComponentGetValue2(var, "value_int") == entity then
+                    table.insert(found, child)
+                end
+            end
+        end
+        cached = { frame = frame, list = found }
+        lukki_cache[entity] = cached
+    end
+    local alive = {}
+    for _, child in ipairs(cached.list) do
+        if EntityGetIsAlive(child) then
+            table.insert(alive, child)
+        end
+    end
+    return alive
+end
+
 local function get_entities(entity)
     local homunculy = {}
     local ghost = {}
@@ -15,18 +58,7 @@ local function get_entities(entity)
             table.insert(ghost, child)
         end
     end
-    local luuki = {}
-    for _, child in ipairs(EntityGetWithTag("lukki") or {}) do
-        if EntityHasTag(child, "perk_entity") then
-            local var = EntityGetComponent(child, "VariableStorageComponent")[2]
-            if var ~= nil then
-                if ComponentGetValue2(var, "value_int") == entity then
-                    table.insert(luuki, child)
-                end
-            end
-        end
-    end
-    return homunculy, luuki, ghost
+    return homunculy, get_lukki(entity), ghost
 end
 rpc.opts_reliable()
 function rpc.send_positions(ho, lu, gh, f)

--- a/quant.ew/files/system/kolmi/append/spawn_kolmi.lua
+++ b/quant.ew/files/system/kolmi/append/spawn_kolmi.lua
@@ -1,19 +1,10 @@
 local old = item_pickup
-function item_pickup(ent, _, _, run)
-    if run == nil then
-        local gid
-        for _, v in ipairs(EntityGetComponent(ent, "VariableStorageComponent") or {}) do
-            if ComponentGetValue2(v, "name") == "ew_gid_lid" then
-                gid = v
-                break
-            end
-        end
-        if gid ~= nil and not ComponentGetValue2(gid, "value_bool") then
-            CrossCall("ew_spawn_kolmi", ComponentGetValue2(gid, "value_string"))
-        else
-            old(ent)
-        end
+function item_pickup(ent, who, name, run)
+    if run then
+        old(ent, who, name)
     else
-        old(ent)
+        -- The fight starts on whichever peer owns Kolmi, which may not be this
+        -- one, so a pickup here only gets reported. See kolmi.lua.
+        CrossCall("ew_sampo_picked")
     end
 end

--- a/quant.ew/files/system/kolmi/kolmi.lua
+++ b/quant.ew/files/system/kolmi/kolmi.lua
@@ -94,14 +94,45 @@ function rpc.kolmi_shield(is_on, orbcount)
     switch_shield(kolmi, is_on)
 end
 
+-- Every peer only records the pickup. Starting the fight is up to whoever owns
+-- Kolmi, in module.on_world_update below.
 rpc.opts_reliable()
-function rpc.spawn_kolmi(gid)
+rpc.opts_everywhere()
+function rpc.sampo_picked()
+    GameAddFlagRun("ew_sampo_picked")
+end
+
+-- Only a Kolmi entity sync has given to this peer. An untracked one has no owner
+-- yet, and a remote copy is overwritten by its owner every frame.
+local function is_mine(ent)
+    for _, v in ipairs(EntityGetComponentIncludingDisabled(ent, "VariableStorageComponent") or {}) do
+        if ComponentGetValue2(v, "name") == "ew_gid_lid" then
+            return ComponentGetValue2(v, "value_bool")
+        end
+    end
+    return false
+end
+
+-- Kolmi's owner is the only peer whose Kolmi really fights; entity sync starts
+-- every other copy once the owner reports the fight has begun. Checked every
+-- frame rather than once when the pickup arrives, so a Kolmi that changes owner
+-- before its fight starts is started by the new owner instead.
+function module.on_world_update()
     if not GameHasFlagRun("ew_sampo_picked") then
-        local item_id = ewext.find_by_gid(gid)
-        if item_id ~= nil and util.do_i_own(item_id) then
-            GameAddFlagRun("ew_sampo_picked")
+        return
+    end
+    for _, kolmi in ipairs(EntityGetWithTag("boss_centipede")) do
+        -- The base script gives up before tagging Kolmi if the arena's reference
+        -- point isn't loaded, and would then replay its sound every frame.
+        if
+            not EntityHasTag(kolmi, "boss_centipede_active")
+            and is_mine(kolmi)
+            and #EntityGetWithTag("reference") > 0
+        then
             dofile("data/entities/animals/boss_centipede/sampo_pickup.lua")
-            item_pickup(item_id, nil, nil, true)
+            -- The picked-up item only decides where the pickup sound and effect
+            -- play, and this peer's copy of the sampo may already be gone.
+            item_pickup(kolmi, nil, nil, true)
             local newgame_n = tonumber(SessionNumbersGetValue("NEW_GAME_PLUS_COUNT"))
             local orbcount = GameGetOrbCountThisRun() + newgame_n
             rpc.kolmi_shield(true, orbcount)
@@ -132,7 +163,7 @@ util.add_cross_call("ew_kolmi_anim", rpc.kolmi_anim)
 
 util.add_cross_call("ew_kolmi_shield", rpc.kolmi_shield)
 
-util.add_cross_call("ew_spawn_kolmi", rpc.spawn_kolmi)
+util.add_cross_call("ew_sampo_picked", rpc.sampo_picked)
 
 --[[ctx.cap.item_sync.register_pickup_handler(function(item_id)
     if ctx.is_host and EntityHasTag(item_id, "this_is_sampo") then

--- a/quant.ew/init.lua
+++ b/quant.ew/init.lua
@@ -341,7 +341,7 @@ function OnProjectileFiredPost(
         if vel ~= nil then
             local x, y = ComponentGetValue2(vel, "mVelocity")
             local m = shooter_player_data.fps / ctx.my_player.fps
-            ComponentSetValue2(vel, x * m, y * m)
+            ComponentSetValue2(vel, "mVelocity", x * m, y * m)
         end
     end
 end

--- a/quant.ew/init.lua
+++ b/quant.ew/init.lua
@@ -245,9 +245,9 @@ function OnProjectileFired(
             rng = (shooter_player_data.projectile_seed_chain[entity_that_shot] or 0) + 25
         end
     end
-    shooter_player_data.projectile_seed_chain[shooter_id - 1] = rng
-    shooter_player_data.projectile_seed_chain[entity_that_shot] = rng
-    shooter_player_data.projectile_seed_chain[projectile_id] = rng
+    player_fns.set_projectile_seed(shooter_player_data, shooter_id - 1, rng)
+    player_fns.set_projectile_seed(shooter_player_data, entity_that_shot, rng)
+    player_fns.set_projectile_seed(shooter_player_data, projectile_id, rng)
     for _, lua in ipairs(EntityGetComponent(projectile_id, "LuaComponent") or {}) do
         local src = ComponentGetValue2(lua, "script_source_file")
         if

--- a/quant.ew/init.lua
+++ b/quant.ew/init.lua
@@ -245,8 +245,13 @@ function OnProjectileFired(
             rng = (shooter_player_data.projectile_seed_chain[entity_that_shot] or 0) + 25
         end
     end
-    player_fns.set_projectile_seed(shooter_player_data, shooter_id - 1, rng)
-    player_fns.set_projectile_seed(shooter_player_data, entity_that_shot, rng)
+    -- `shooter_id - 1`, key 0 and the world-state entity are read back on every
+    -- shot for the rest of the session, so they must not be evicted by the ring
+    -- in set_projectile_seed. `projectile_id` (and `entity_that_shot` when it is
+    -- a parent projectile) is only read while its chain is still firing.
+    local shot_is_anchor = projectileComponent == nil or entity_that_shot == 0
+    player_fns.set_projectile_seed(shooter_player_data, shooter_id - 1, rng, true)
+    player_fns.set_projectile_seed(shooter_player_data, entity_that_shot, rng, shot_is_anchor)
     player_fns.set_projectile_seed(shooter_player_data, projectile_id, rng)
     for _, lua in ipairs(EntityGetComponent(projectile_id, "LuaComponent") or {}) do
         local src = ComponentGetValue2(lua, "script_source_file")
@@ -340,7 +345,16 @@ function OnProjectileFiredPost(
         local vel = EntityGetFirstComponentIncludingDisabled(projectile_id, "VelocityComponent")
         if vel ~= nil then
             local x, y = ComponentGetValue2(vel, "mVelocity")
-            local m = shooter_player_data.fps / ctx.my_player.fps
+            -- player_sync.update_fps stores math.min(60, math.floor(fps + 0.5)),
+            -- which is 0 on a stalled frame (and nan if two samples land in the
+            -- same real-world millisecond); the field is also absent until the
+            -- first update. Any of those would make this ratio inf or nan and
+            -- fling the projectile at a garbage velocity, so fall back to 1x.
+            local their_fps, my_fps = shooter_player_data.fps, ctx.my_player.fps
+            local m = 1
+            if their_fps ~= nil and my_fps ~= nil and their_fps > 0 and my_fps > 0 then
+                m = their_fps / my_fps
+            end
             ComponentSetValue2(vel, "mVelocity", x * m, y * m)
         end
     end

--- a/quant.ew/init.lua
+++ b/quant.ew/init.lua
@@ -35,7 +35,7 @@ dofile_once("data/scripts/lib/coroutines.lua")
 ModLuaFileAppend("data/scripts/gun/gun.lua", "mods/quant.ew/files/resource/append/gun.lua")
 ModLuaFileAppend("data/scripts/gun/gun_actions.lua", "mods/quant.ew/files/resource/append/action_fix.lua")
 
-if ModSettingGet("quant.ew.enable_log") or true then
+if ModSettingGet("quant.ew.enable_log") then
     ModMagicNumbersFileAdd("mods/quant.ew/files/magic_numbers.xml")
 else
     ModMagicNumbersFileAdd("mods/quant.ew/files/magic.xml")

--- a/quant.ew/settings.lua
+++ b/quant.ew/settings.lua
@@ -293,8 +293,8 @@ local function build_settings()
                 },
                 {
                     id = "cache",
-                    ui_name = "cache entities",
-                    ui_description = "cache entity data to improve performance",
+                    ui_name = "bypass entity cache",
+                    ui_description = "re-read entity data from the game every frame instead of caching it. slower; only for debugging desyncs",
                     value_default = false,
                     scope = MOD_SETTING_SCOPE_RUNTIME,
                 },

--- a/shared/src/message_socket.rs
+++ b/shared/src/message_socket.rs
@@ -41,6 +41,10 @@ pub struct MessageSocket<Inbound, Outbound> {
 impl<Inbound: DecodeOwned + Send + 'static, Outbound: Encode> MessageSocket<Inbound, Outbound> {
     pub fn new(socket: TcpStream) -> eyre::Result<Self> {
         socket.set_write_timeout(Some(Duration::from_secs(10)))?;
+        // The proxy sets this on its accepted sockets, but the ewext side (which
+        // connects) never did - leaving Nagle enabled on the game -> proxy
+        // direction, which is the one on the frame-critical path.
+        socket.set_nodelay(true)?;
         let (sender, recv_messages) = mpsc::channel();
         let reader_thread = Some(thread::spawn({
             let socket = socket.try_clone()?;
@@ -60,7 +64,10 @@ impl<Inbound: DecodeOwned + Send + 'static, Outbound: Encode> MessageSocket<Inbo
         }));
 
         Ok(Self {
-            socket: BufWriter::new(socket),
+            // A single world-sync chunk can reach ~82 KB; with the default 8 KB
+            // BufWriter capacity every such message went straight to the kernel
+            // and could block the game thread. Size the buffer past that.
+            socket: BufWriter::with_capacity(256 * 1024, socket),
             recv_messages,
             reader_thread,
             _phantom: PhantomData,


### PR DESCRIPTION
These are probably the really fragile ones of the batch that I'm sending up. The big changes to the entity cache here should make scripts a bit more predictable in their behavior and how entities are synced.

This still feels like a bit of bandaid patchwork, but without a bigger ripout of this entity cache system or more drastic changes to the engine, this felt like the split that brought me the most confidence.

Included here is also a nice little hack to stop the spells/wands falling through the holy mountain. Seems to work much better in practice.