### PR TITLE
Couple miscellaneous fixes

### DIFF
--- a/quant.ew/files/core/net_handling.lua
+++ b/quant.ew/files/core/net_handling.lua
@@ -231,7 +231,9 @@ function net_handling.mod.fire(peer_id, fire_data)
                 util.set_ent_firing_blocked(entity, false)
 
                 EntityAddTag(entity, "player_unit")
-                np.UseItem(entity, mActiveItem, true, true, true, x, y, target_x, target_y)
+                -- np.UseItem can throw errors from hooks, catch and log so we
+                -- can make sure the cleanup below happens
+                util.tpcall(np.UseItem, entity, mActiveItem, true, true, true, x, y, target_x, target_y)
                 EntityRemoveTag(entity, "player_unit")
 
                 util.set_ent_firing_blocked(entity, true)

--- a/quant.ew/files/core/player_fns.lua
+++ b/quant.ew/files/core/player_fns.lua
@@ -498,7 +498,7 @@ function player_fns.deserialize_position(message, phys_infos, player_data)
     ComponentSetValue2(velocity_comp, "gravity_y", 0)
 
     if not util.set_phys_info(entity, phys_infos, player_data.fps) then
-        local m = player_data.fps / ctx.my_player.fps
+        local m = util.fps_ratio(player_data.fps, ctx.my_player.fps)
         ComponentSetValue2(character_data, "mVelocity", message.vel_x * m, message.vel_y * m)
         EntityApplyTransform(entity, message.x, message.y)
     end

--- a/quant.ew/files/core/util.lua
+++ b/quant.ew/files/core/util.lua
@@ -424,12 +424,27 @@ local function serialize_phys_component(phys_component)
     end
 end
 
+-- The multiplier for carrying a per-frame quantity from a peer running at
+-- `from_fps` to one running at `to_fps`. player_sync.update_fps stores
+-- math.min(60, math.floor(fps + 0.5)): its first sample is frames-since-launch
+-- over seconds-since-launch, which rounds to 0 on a peer that has spent most of
+-- its life not drawing frames, and it is nan if two samples land in the same
+-- real-world millisecond. Either of those in the denominator gives inf or nan,
+-- which then gets written into a lifetime or a velocity, so fall back to
+-- carrying the quantity over unscaled.
+function util.fps_ratio(from_fps, to_fps)
+    if from_fps ~= nil and to_fps ~= nil and from_fps > 0 and to_fps > 0 then
+        return from_fps / to_fps
+    end
+    return 1
+end
+
 local function deserialize_phys_component(phys_component, phys_info, fps)
     local x, y = GamePosToPhysicsPos(phys_info.x, phys_info.y)
     if ffi.typeof(phys_info) == PhysDataNoMotion then
         np.PhysBodySetTransform(phys_component, x, y, phys_info.r / 255 * FULL_TURN, 0, 0, 0)
     else
-        local m = fps / ctx.my_player.fps
+        local m = util.fps_ratio(fps, ctx.my_player.fps)
         np.PhysBodySetTransform(
             phys_component,
             x,

--- a/quant.ew/files/system/karl/karl.lua
+++ b/quant.ew/files/system/karl/karl.lua
@@ -59,7 +59,7 @@ function rpc.send_karl(x, y, vx, vy, t, jet, rgb1, rgb2)
     end
     EntitySetComponentsWithTagEnabled(players_karl, "jetpack", jet)
     local vel = EntityGetFirstComponentIncludingDisabled(players_karl, "VelocityComponent")
-    local m = ctx.rpc_player_data.fps / ctx.my_player.fps
+    local m = util.fps_ratio(ctx.rpc_player_data.fps, ctx.my_player.fps)
     ComponentSetValue2(vel, "mVelocity", vx * m, vy * m)
 end
 

--- a/quant.ew/init.lua
+++ b/quant.ew/init.lua
@@ -307,13 +307,15 @@ function OnProjectileFired(
             if proj ~= nil then
                 local lif = ComponentGetValue2(proj, "lifetime")
                 if lif > 0 then
-                    ComponentSetValue2(proj, "lifetime", lif * ctx.my_player.fps / shooter_player_data.fps)
+                    local m = util.fps_ratio(ctx.my_player.fps, shooter_player_data.fps)
+                    ComponentSetValue2(proj, "lifetime", lif * m)
                 end
             end
             if life ~= nil then
                 local lif = ComponentGetValue2(life, "lifetime")
                 if lif > 0 then
-                    ComponentSetValue2(life, "lifetime", lif * ctx.my_player.fps / shooter_player_data.fps)
+                    local m = util.fps_ratio(ctx.my_player.fps, shooter_player_data.fps)
+                    ComponentSetValue2(life, "lifetime", lif * m)
                 end
             end
             if body ~= nil then
@@ -354,16 +356,7 @@ function OnProjectileFiredPost(
         local vel = EntityGetFirstComponentIncludingDisabled(projectile_id, "VelocityComponent")
         if vel ~= nil then
             local x, y = ComponentGetValue2(vel, "mVelocity")
-            -- player_sync.update_fps stores math.min(60, math.floor(fps + 0.5)),
-            -- which is 0 on a stalled frame (and nan if two samples land in the
-            -- same real-world millisecond); the field is also absent until the
-            -- first update. Any of those would make this ratio inf or nan and
-            -- fling the projectile at a garbage velocity, so fall back to 1x.
-            local their_fps, my_fps = shooter_player_data.fps, ctx.my_player.fps
-            local m = 1
-            if their_fps ~= nil and my_fps ~= nil and their_fps > 0 and my_fps > 0 then
-                m = their_fps / my_fps
-            end
+            local m = util.fps_ratio(shooter_player_data.fps, ctx.my_player.fps)
             ComponentSetValue2(vel, "mVelocity", x * m, y * m)
         end
     end

--- a/quant.ew/init.lua
+++ b/quant.ew/init.lua
@@ -162,6 +162,18 @@ end
 
 local last_mana = -1
 
+-- Whether a projectile with this lifetime component still exists in `frames`
+-- frames. A missing component puts no bound on the projectile's life at all,
+-- and so does a negative lifetime: rock.xml and propane_tank.xml ship with
+-- ProjectileComponent lifetime -1 and no LifetimeComponent whatsoever.
+local function outlives(component, frames)
+    if component == nil then
+        return true
+    end
+    local lifetime = ComponentGetValue2(component, "lifetime")
+    return lifetime == nil or lifetime < 0 or lifetime > frames
+end
+
 local function fire()
     local inventory_component = EntityGetFirstComponentIncludingDisabled(ctx.my_player.entity, "Inventory2Component")
     if inventory_component ~= nil then
@@ -286,7 +298,7 @@ function OnProjectileFired(
         local body = EntityGetFirstComponentIncludingDisabled(projectile_id, "PhysicsBody2Component")
         local proj = EntityGetFirstComponentIncludingDisabled(projectile_id, "ProjectileComponent")
         local life = EntityGetFirstComponentIncludingDisabled(projectile_id, "LifetimeComponent")
-        if proj == nil or ComponentGetValue2(proj, "lifetime") > 4 or ComponentGetValue2(life, "lifetime") > 4 then
+        if outlives(proj, 4) or outlives(life, 4) then
             if EntityGetIsAlive(projectile_id) then
                 ewext.sync_projectile(projectile_id, shooter_player_data.peer_id, rng)
             end


### PR DESCRIPTION
From discord:

```
Lua error - ComponentGetValue2( component_id:int, field_name:string )
  couldn't find component with id: 0
  Stack traceback:
      [string "mods/quant.ew/init.lua"]:287: in function <[string "mods/quant.ew/init.lua"]:184>
      [C]: in function 'UseItem'
      [string "mods/quant.ew/files/core/net_handling.lua"]:234: in function <[string "mods/quant.ew/files/core/net_handling.lua"]:176>
      [C]: in function 'xpcall'
      [string "mods/quant.ew/files/core/util.lua"]:62: in function 'tpcall'
      [string "mods/quant.ew/files/core/net.lua"]:157: in function 'handle_message'
      [string "mods/quant.ew/files/core/net.lua"]:172: in function 'update'
      [string "mods/quant.ew/init.lua"]:489: in function <[string "mods/quant.ew/init.lua"]:482>
      [C]: in function 'xpcall'
      [string "mods/quant.ew/files/core/util.lua"]:62: in function 'tpcall'
      [string "mods/quant.ew/init.lua"]:605: in function <[string "mods/quant.ew/init.lua"]:596>
LUA: [string "mods/quant.ew/init.lua"]:287: attempt to compare number with nil
Lua error - (skipping logging of recurring lua errors)
LUA: [string "mods/quant.ew/init.lua"]:287: attempt to compare number with nil
```

and `bruh i cant kill endboss`.

I did some searching and found rock/propane had the potential to trigger this, asked, and they had been using a rock wand.

I don't think this is related to the kolmi not finishing bug, I believe they were running an old version (said they didn't have native rust decode in settings menu).